### PR TITLE
Faster exchange

### DIFF
--- a/qcpanop/pw_pbc/basis.py
+++ b/qcpanop/pw_pbc/basis.py
@@ -228,6 +228,25 @@ class plane_wave_basis():
 
         self.charge = cell.charge
 
+        # precompute FFT[1/|r-r'|/g2]
+        self.inv_g2 = np.zeros_like(self.g2)
+        mask = self.g2 != 0.0
+        self.inv_g2[mask] = 1.0 / self.g2[mask]
+
+        # precompute flat index in FFT grid ordering for each compact G index
+        self.flat_idx = np.empty(len(self.g), dtype=np.int64)
+        for myg in range(len(self.g)):
+            ix, iy, iz = get_miller_indices(myg, self)
+            self.flat_idx[myg] = np.ravel_multi_index((ix, iy, iz), self.real_space_grid_dim)
+
+        # precompute linear grid indices for each k-point
+        self.grid_idx_k = []
+        for kid in range ( len(self.kpts) ):
+            ijk = np.array([get_miller_indices(ik, self) for ik in self.kg_to_g[kid]])
+            coords = tuple(ijk.T)
+            self.grid_idx_k.append(np.ravel_multi_index(coords, self.real_space_grid_dim))
+
+
 
 def get_plane_waves_per_k(ke_cutoff, k, g):
 

--- a/qcpanop/pw_pbc/run_jellium.py
+++ b/qcpanop/pw_pbc/run_jellium.py
@@ -46,7 +46,8 @@ def main():
     en, ca, cb = uks(cell, basis, xc = 'hf', guess_mix = False, maxiter = 1, ace_exchange = True, jellium = True, jellium_ne = 100)
 
     # jellium / 3.22 ev / omega = 2^18 / ne = 100
-    assert np.isclose(en, -3.932033059623)
+    #assert np.isclose(en, -3.932033059623)
+    assert np.isclose(en, -3.939694759636)
 
     # C / diamond / hf / gth-pbe / 500 ev cutoff
     #assert np.isclose(en, -10.061105991782)

--- a/qcpanop/pw_pbc/run_jellium.py
+++ b/qcpanop/pw_pbc/run_jellium.py
@@ -15,14 +15,10 @@ import numpy as np
 def main():
 
     # define unit cell 
-    
-    ase_atom = bulk('C', 'diamond', a = 6.74)
-
-    atom = pyscf_ase.ase_atoms_to_pyscf(ase_atom)
-    a = ase_atom.cell 
-
-    #a = np.eye(3) * 64.0
-    #atom = 'He 0 0 0'
+   
+    # omega = 2^18 a0^3 
+    a = np.eye(3) * 64.0
+    atom = 'He 0 0 0'
     
     cell = gto.M(a = a,
                  atom = atom,
@@ -30,17 +26,16 @@ def main():
                  basis = 'sto-3g', #'cc-pvdz',
                  pseudo = 'gth-pbe',
                  #verbose = 100,
-                 ke_cutoff = 10 / 27.21138602,
-                 precision = 1.0e-8,
+                 ke_cutoff = 0.01 / 27.21138602,
+                 precision = 1.0,
                  charge = 0,
                  spin = 0,
                  dimension = 3)
 
     cell.build()
 
-    #cutoff = 3.22
+    cutoff = 3.22
     #cutoff = 12.917
-    cutoff = 1000
 
     # get plane wave basis information
     basis = plane_wave_basis(cell, 
@@ -48,17 +43,17 @@ def main():
         n_kpts = [1, 1, 1])
 
     # run plane wave scf 
-    #en, ca, cb = uks(cell, basis, xc = 'hf', guess_mix = True, maxiter = 1, ace_exchange = True, jellium = True, jellium_ne = 40)
-    en, ca, cb = uks(cell, basis, xc = 'hf', guess_mix = True, maxiter = 100, ace_exchange = True)
+    en, ca, cb = uks(cell, basis, xc = 'hf', guess_mix = True, maxiter = 1, ace_exchange = True, jellium = True, jellium_ne = 100)
+    #en, ca, cb = uks(cell, basis, xc = 'hf', guess_mix = True, maxiter = 100, ace_exchange = True)
 
-    # C / diamond / pbe / gth-pbe / 1000 ev cutoff
-    #assert np.isclose(en, -10.281221451484)
+    # jellium / 3.22 ev / omega = 2^18 / ne = 100
+    assert np.isclose(en, -3.932033059623)
 
     # C / diamond / hf / gth-pbe / 500 ev cutoff
     #assert np.isclose(en, -10.061105991782)
 
     # C / diamond / hf / gth-pbe / 1000 ev cutoff
-    assert np.isclose(en, -10.236907018105)
+    #assert np.isclose(en, -10.236907018105)
 
     # C / diamond / hf / gth-pbe / 2000 ev cutoff
     #assert np.isclose(en, -10.249995429892)

--- a/qcpanop/pw_pbc/run_jellium.py
+++ b/qcpanop/pw_pbc/run_jellium.py
@@ -43,8 +43,7 @@ def main():
         n_kpts = [1, 1, 1])
 
     # run plane wave scf 
-    en, ca, cb = uks(cell, basis, xc = 'hf', guess_mix = True, maxiter = 1, ace_exchange = True, jellium = True, jellium_ne = 100)
-    #en, ca, cb = uks(cell, basis, xc = 'hf', guess_mix = True, maxiter = 100, ace_exchange = True)
+    en, ca, cb = uks(cell, basis, xc = 'hf', guess_mix = False, maxiter = 1, ace_exchange = True, jellium = True, jellium_ne = 100)
 
     # jellium / 3.22 ev / omega = 2^18 / ne = 100
     assert np.isclose(en, -3.932033059623)

--- a/qcpanop/pw_pbc/run_pw_uks.py
+++ b/qcpanop/pw_pbc/run_pw_uks.py
@@ -21,6 +21,7 @@ def main():
 
     #ase_atom = bulk('Si', 'diamond', a = 10.26)
     ase_atom = bulk('C', 'diamond', a = 6.74)
+    #ase_atom = bulk('He', 'diamond', a = 4.0)
     #ase_atom = bulk('H', 'diamond', a = 8.88)
     #ase_atom = bulk('Ne', 'diamond', a = 10.26)
 
@@ -31,25 +32,36 @@ def main():
                  atom = atom,
                  unit = 'bohr',
                  basis = 'cc-pvdz',
-                 pseudo = 'gth-blyp',
+                 pseudo = 'gth-pbe',
                  #verbose = 100,
-                 #ke_cutoff = 500 / 27.21138602,
+                 #ke_cutoff = 1000 / 27.21138602,
                  precision = 1.0e-8,
-                 #charge = 0,
-                 spin = 1,
+                 charge = 0,
+                 spin = 0,
                  dimension = 3)
-    
+
     cell.build()
 
-    cutoff = 1000.0
+    cutoff = 1000.0 
 
     # get plane wave basis information
     basis = plane_wave_basis(cell, 
         ke_cutoff = cutoff / 27.21138602, 
         n_kpts = [1, 1, 1])
 
+    #mf = dft.UKS(cell) #, kpts=cell.make_kpts([1, 1, 1]))
+    #mf.xc = 'lda'
+    #energy = mf.kernel()
+    #print(energy)
+
     # run plane wave scf 
-    en = uks(cell, basis, xc = 'pbe', guess_mix = True)
+    en, ca, cb = uks(cell, basis, xc = 'pbe', guess_mix = True)
+
+    # C / diamond / pbe / gth-pbe / 1000 ev cutoff
+    assert np.isclose(en, -10.281221451484)
+
+    # hf / 300 ev cutoff
+    #assert np.isclose(en, -10.453404153698)
 
 if __name__ == "__main__":
     main()

--- a/qcpanop/pw_pbc/run_pw_uks.py
+++ b/qcpanop/pw_pbc/run_pw_uks.py
@@ -48,8 +48,7 @@ def main():
         n_kpts = [1, 1, 1])
 
     # run plane wave scf 
-    #en, ca, cb = uks(cell, basis, xc = 'hf', guess_mix = True, maxiter = 1, ace_exchange = True, jellium = True, jellium_ne = 40)
-    en, ca, cb = uks(cell, basis, xc = 'hf', guess_mix = True, maxiter = 100, ace_exchange = True)
+    en, ca, cb = uks(cell, basis, xc = 'hf', guess_mix = False, maxiter = 100, ace_exchange = True)
 
     # C / diamond / pbe / gth-pbe / 1000 ev cutoff
     #assert np.isclose(en, -10.281221451484)

--- a/qcpanop/pw_pbc/run_pw_uks.py
+++ b/qcpanop/pw_pbc/run_pw_uks.py
@@ -3,7 +3,6 @@ from qcpanop.pw_pbc.pseudopotential import get_nonlocal_pseudopotential_matrix_e
 from qcpanop.pw_pbc.basis import plane_wave_basis 
 from qcpanop.pw_pbc.scf import uks
 
-from pyscf import dft, scf, pbc
 from pyscf.pbc import gto, scf
 
 import ase
@@ -27,10 +26,10 @@ def main():
     cell = gto.M(a = a,
                  atom = atom,
                  unit = 'bohr',
-                 basis = 'sto-3g', #'cc-pvdz',
+                 basis = 'cc-pvdz',
                  pseudo = 'gth-pbe',
                  #verbose = 100,
-                 ke_cutoff = 10 / 27.21138602,
+                 ke_cutoff = 1000 / 27.21138602,
                  precision = 1.0e-8,
                  charge = 0,
                  spin = 0,
@@ -38,8 +37,6 @@ def main():
 
     cell.build()
 
-    #cutoff = 3.22
-    #cutoff = 12.917
     cutoff = 1000
 
     # get plane wave basis information
@@ -47,8 +44,9 @@ def main():
         ke_cutoff = cutoff / 27.21138602, 
         n_kpts = [1, 1, 1])
 
-    # run plane wave scf 
-    en, ca, cb = uks(cell, basis, xc = 'hf', guess_mix = False, maxiter = 100, ace_exchange = True)
+    # run plane wave scf
+    kBT = None #1.5 / 27.21138602 
+    en, ca, cb = uks(cell, basis, xc = 'hf', guess_mix = True, maxiter = 100, ace_exchange = True, kBT = kBT)
 
     # C / diamond / pbe / gth-pbe / 1000 ev cutoff
     #assert np.isclose(en, -10.281221451484)
@@ -65,6 +63,8 @@ def main():
     # C / diamond / hf / gth-pbe / 3000 ev cutoff
     #assert np.isclose(en, -10.25032156584)
 
+    # C / diamond / hf / gth-pbe / 4000 ev cutoff
+    #assert np.isclose(en, -10.25032908497)
 
 if __name__ == "__main__":
     main()

--- a/qcpanop/pw_pbc/run_pw_uks.py
+++ b/qcpanop/pw_pbc/run_pw_uks.py
@@ -1,6 +1,6 @@
 
 from qcpanop.pw_pbc.pseudopotential import get_nonlocal_pseudopotential_matrix_elements
-from qcpanop.pw_pbc.basis import plane_wave_basis
+from qcpanop.pw_pbc.basis import plane_wave_basis 
 from qcpanop.pw_pbc.scf import uks
 
 from pyscf import dft, scf, pbc
@@ -42,26 +42,31 @@ def main():
 
     cell.build()
 
-    cutoff = 1000.0 
+    cutoff = 500.0 
 
     # get plane wave basis information
     basis = plane_wave_basis(cell, 
         ke_cutoff = cutoff / 27.21138602, 
         n_kpts = [1, 1, 1])
 
-    #mf = dft.UKS(cell) #, kpts=cell.make_kpts([1, 1, 1]))
-    #mf.xc = 'lda'
-    #energy = mf.kernel()
-    #print(energy)
-
     # run plane wave scf 
-    en, ca, cb = uks(cell, basis, xc = 'pbe', guess_mix = True)
+    en, ca, cb = uks(cell, basis, xc = 'hf', guess_mix = True, maxiter = 100, ace_exchange = True)
 
     # C / diamond / pbe / gth-pbe / 1000 ev cutoff
-    assert np.isclose(en, -10.281221451484)
+    #assert np.isclose(en, -10.281221451484)
 
-    # hf / 300 ev cutoff
-    #assert np.isclose(en, -10.453404153698)
+    # C / diamond / hf / gth-pbe / 500 ev cutoff
+    assert np.isclose(en, -10.061105991782)
+
+    # C / diamond / hf / gth-pbe / 1000 ev cutoff
+    #assert np.isclose(en, -10.236907018105)
+
+    # C / diamond / hf / gth-pbe / 2000 ev cutoff
+    #assert np.isclose(en, -10.249995429892)
+
+    # C / diamond / hf / gth-pbe / 3000 ev cutoff
+    #assert np.isclose(en, -10.25032156584)
+
 
 if __name__ == "__main__":
     main()

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -26,7 +26,7 @@ from qcpanop.pw_pbc.basis import get_miller_indices
 
 from pyscf.pbc import tools
 
-def get_exact_exchange_energy(basis, occupied_orbitals, N, C):
+def get_exact_exchange_energy(basis, occupied_orbitals, N, C, exchange_matrix, compute_exchange_matrix = False):
     """
 
     evaluate the exact Hartree-Fock exchange energy, according to
@@ -77,6 +77,9 @@ def get_exact_exchange_energy(basis, occupied_orbitals, N, C):
 
             exchange_energy += np.sum( Cij.conj() * Kij )
 
+    if not compute_exchange_matrix :
+        return -2.0 * np.pi / basis.omega * exchange_energy, exchange_matrix
+
     #        # Kij(r) = FFT^-1[Kij(g)]
     #        Kij_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
     #        for myg in range( len(basis.g) ):
@@ -119,7 +122,7 @@ def get_exact_exchange_energy(basis, occupied_orbitals, N, C):
     Kij_G = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
 
     # try new way ...
-    exchange_matrix = np.zeros((basis.n_plane_waves_per_k[0], basis.n_plane_waves_per_k[0]), dtype='complex128')
+    #exchange_matrix = np.zeros((basis.n_plane_waves_per_k[0], basis.n_plane_waves_per_k[0]), dtype='complex128')
 
     for i in range(0, basis.n_plane_waves_per_k[0]):
         ii = basis.kg_to_g[0][i]
@@ -801,249 +804,221 @@ def uks(cell, basis,
         Calpha.append(np.eye(basis.n_plane_waves_per_k[kid]))
         Cbeta.append(np.eye(basis.n_plane_waves_per_k[kid]))
 
-    # outer diis extrapolates density
+    # diis extrapolates fock matrix
     from pyscf import lib
-    outer_diis = lib.diis.DIIS()
-    outer_diis.space = diis_dimension
+    inner_diis = lib.diis.DIIS()
+    inner_diis.space = diis_dimension
 
-    # inner diis extrapolates fock matrix
-    #inner_diis = lib.diis.DIIS()
-    #inner_diis.space = diis_dimension
-
+    # begin UKS iterations
     xc_energy = 0.0
-    for outer_scf_iter in range (maxiter):
+    scf_iter = 0 # initialize variable incase maxiter = 0
+    one_electron_energy = 0.0
+    coulomb_energy = 0.0
+    recompute_exchange = False
 
-        # inner diis extrapolates fock matrix
-        inner_diis = lib.diis.DIIS()
-        inner_diis.space = diis_dimension
+    for scf_iter in range(maxiter):
 
-        # begin UKS iterations
-        scf_iter = 0 # initialize variable incase maxiter = 0
+        occ_alpha = []
+        occ_beta = []
+
         one_electron_energy = 0.0
         coulomb_energy = 0.0
 
-        for scf_iter in range(maxiter):
-
-            occ_alpha = []
-            occ_beta = []
-
-            one_electron_energy = 0.0
-            coulomb_energy = 0.0
-
-            if xc != 'hf' :
-                va = v_coulomb + v_ne + v_xc_alpha
-                vb = v_coulomb + v_ne + v_xc_beta
-            else :
-                va = v_coulomb + v_ne 
-                vb = v_coulomb + v_ne 
-
-            # zero density for this iteration
-            rho = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
-
-            # form fock matrix and orbital gradient
-
-            fock_a = []
-            fock_b = []
-            grad_a = []
-            grad_b = []
-
-            for kid in range ( len(basis.kpts) ):
-                fock_a.append(np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128'))
-                fock_b.append(np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128'))
-                grad_a.append(np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128'))
-                grad_b.append(np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128'))
-
-            # damping factor
-            damp = 1.0
-            if outer_scf_iter == 0 and scf_iter < diis_start_cycle and damp_fock : 
-                damp = damping_factor
-
-            # loop over k-points
-            for kid in range( len(basis.kpts) ):
-
-                # form fock matrix
-                fock_a[kid] = form_fock_matrix(basis, kid, v = va)
-                fock_b[kid] = form_fock_matrix(basis, kid, v = vb)
-
-                # exact exchange?
-                if xc == 'hf' :
-                    fock_a += exchange_matrix_alpha
-                    fock_b += exchange_matrix_beta
-
-                # damp fock matrix
-                fock_a[kid] = damp * fock_a[kid] + (1.0 - damp) * old_fock_a[kid]
-                fock_b[kid] = damp * fock_b[kid] + (1.0 - damp) * old_fock_b[kid]
-                old_fock_a[kid] = fock_a[kid].copy()
-                old_fock_b[kid] = fock_b[kid].copy()
-
-                # form opdm and orbital gradient (for diis)
-                grad_a[kid] = form_orbital_gradient(basis, Calpha[kid], nalpha, fock_a[kid], kid)
-                grad_b[kid] = form_orbital_gradient(basis, Cbeta[kid], nbeta, fock_b[kid], kid)
-
-            # extrapolate fock matrix
-
-            # solution vector is fock matrix
-            solution_vector = np.zeros(0)
-            for kid in range ( len(basis.kpts) ):
-                solution_vector = np.hstack( (solution_vector, fock_a[kid].flatten(), fock_b[kid].flatten() ) )
-
-            # error vector is orbital gradient
-            error_vector = np.zeros(0)
-            for kid in range ( len(basis.kpts) ):
-                error_vector = np.hstack( (error_vector, grad_a[kid].flatten(), grad_b[kid].flatten() ) )
-
-            # norm of orbital gradient
-            conv = np.linalg.norm(error_vector)
-
-            # extrapolate solution vector
-            new_solution_vector = inner_diis.update(solution_vector, error_vector)
-
-            # reshape solution vector
-            off = 0
-            for kid in range ( len(basis.kpts) ):
-                dim = basis.n_plane_waves_per_k[kid]
-                fock_a[kid] = new_solution_vector[off:off+dim*dim].reshape(fock_a[kid].shape)
-                off += dim*dim
-                fock_b[kid] = new_solution_vector[off:off+dim*dim].reshape(fock_b[kid].shape)
-                off += dim*dim
-
-            one_electron_energy = 0.0
-            coulomb_energy = 0.0
-
-            rho_a = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
-            rho_b = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
-
-            # diagonalize extrapolated fock matrix
-            for kid in range ( len(basis.kpts) ):
-
-                n = nalpha - 1
-                if scf_iter == 0 and guess_mix == True :
-                    n = nalpha
-
-                epsilon_alpha, Calpha[kid] = scipy.linalg.eigh(fock_a[kid], eigvals=(0, n))
-                epsilon_beta, Cbeta[kid] = scipy.linalg.eigh(fock_b[kid], eigvals=(0, (nbeta-1)))
-
-                #epsilon_alpha, Calpha = np.linalg.eigh(fock_a)
-                #epsilon_beta, Cbeta = np.linalg.eigh(fock_b)
-
-                # break spin symmetry?
-                if guess_mix is True and scf_iter == 0:
-
-                    c = np.cos(0.25 * np.pi)
-                    s = np.sin(0.25 * np.pi)
-
-                    tmp1 = c * Calpha[kid][:, nalpha-1] - s * Calpha[kid][:, nalpha]
-                    tmp2 = s * Calpha[kid][:, nalpha-1] + c * Calpha[kid][:, nalpha]
-
-                    Calpha[kid][:, nalpha-1] = tmp1
-                    Calpha[kid][:, nalpha] = tmp2
-
-                # update density
-                my_rho_a, occ_alpha = get_density(basis, Calpha[kid], nalpha, kid)
-                my_rho_b, occ_beta = get_density(basis, Cbeta[kid], nbeta, kid)
-
-                # density should be non-negative ...
-                rho_a += my_rho_a.clip(min = 0)
-                rho_b += my_rho_b.clip(min = 0)
-
-                # one-electron part of the energy (alpha)
-                one_electron_energy += get_one_electron_energy(basis, 
-                                                               Calpha[kid], 
-                                                               nalpha, 
-                                                               kid, 
-                                                               v_ne = v_ne)
-
-                # one-electron part of the energy (beta)
-                one_electron_energy += get_one_electron_energy(basis, 
-                                                               Cbeta[kid], 
-                                                               nbeta, 
-                                                               kid, 
-                                                               v_ne = v_ne)
-
-                # coulomb part of the energy: 1/2 J
-                coulomb_energy += get_coulomb_energy(basis, Calpha[kid], nalpha, kid, v_coulomb)
-
-                # coulomb part of the energy: 1/2 J
-                coulomb_energy += get_coulomb_energy(basis, Cbeta[kid], nbeta, kid, v_coulomb)
-
-            rho = rho_a + rho_b
-
-            if xc != 'hf':
-
-                xc_energy = get_xc_energy(xc, basis, rho_a, rho_b, libxc_x_functional, libxc_c_functional)
-
-            else :
-
-                # TODO: fix for general k
-                pass
-                #xc_energy, v_xc = get_exact_exchange_energy(basis, occ_alpha, nalpha, Calpha)
-                #if nbeta > 0:
-                #    my_xc_energy, v_xc = get_exact_exchange_energy(basis, occ_beta, nbeta, Cbeta)
-                #    xc_energy += my_xc_energy
-
-                #xc_energy -= 0.5 * (nalpha + nbeta) * madelung
-
-            # coulomb potential
-            tmp = np.fft.ifftn(rho)
-            for myg in range( len(basis.g) ):
-                inner_rhog[myg] = tmp[ get_miller_indices(myg, basis) ]
-
-            v_coulomb = 4.0 * np.pi * np.divide(inner_rhog, basis.g2, out = np.zeros_like(basis.g2), where = basis.g2 != 0.0)
-
-            # exchange-correlation potential
-            if xc != 'hf' :
-
-                v_xc_alpha, v_xc_beta = get_xc_potential(xc, basis, rho_a, rho_b, libxc_x_functional, libxc_c_functional)
-
-            else :
-
-                pass
-                #dum, exchange_matrix_alpha = get_exact_exchange_energy(basis, occ_alpha, nalpha, Calpha)
-                #if nbeta > 0:
-                #    dum, exchange_matrix_beta = get_exact_exchange_energy(basis, occ_beta, nbeta, Cbeta)
-
-            # total energy
-            new_total_energy = np.real(one_electron_energy) + np.real(coulomb_energy) + np.real(xc_energy) + enuc
-
-            # convergence in energy
-            energy_diff = np.abs(new_total_energy - old_total_energy)
-
-            # update energy
-            old_total_energy = new_total_energy
-
-            # charge
-            charge = ( basis.omega / ( basis.real_space_grid_dim[0] * basis.real_space_grid_dim[1] * basis.real_space_grid_dim[2] ) ) * np.sum(np.absolute(rho))
-
-            print("    %5i %5i %20.12lf %20.12lf %20.12lf %10.6lf" %  ( outer_scf_iter, scf_iter, new_total_energy, energy_diff, conv, charge ) )
-
-            if ( conv < d_convergence and energy_diff < e_convergence ) :
-                break
-
         if xc != 'hf' :
+            va = v_coulomb + v_ne + v_xc_alpha
+            vb = v_coulomb + v_ne + v_xc_beta
+        else :
+            va = v_coulomb + v_ne 
+            vb = v_coulomb + v_ne 
+
+        # zero density for this iteration
+        rho = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
+
+        # form fock matrix and orbital gradient
+
+        fock_a = []
+        fock_b = []
+        grad_a = []
+        grad_b = []
+
+        for kid in range ( len(basis.kpts) ):
+            fock_a.append(np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128'))
+            fock_b.append(np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128'))
+            grad_a.append(np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128'))
+            grad_b.append(np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128'))
+
+        # damping factor
+        damp = 1.0
+        if scf_iter < diis_start_cycle and damp_fock : 
+            damp = damping_factor
+
+        # loop over k-points
+        for kid in range( len(basis.kpts) ):
+
+            # form fock matrix
+            fock_a[kid] = form_fock_matrix(basis, kid, v = va)
+            fock_b[kid] = form_fock_matrix(basis, kid, v = vb)
+
+            # exact exchange?
+            if xc == 'hf' :
+                fock_a += exchange_matrix_alpha
+                fock_b += exchange_matrix_beta
+
+            # damp fock matrix
+            fock_a[kid] = damp * fock_a[kid] + (1.0 - damp) * old_fock_a[kid]
+            fock_b[kid] = damp * fock_b[kid] + (1.0 - damp) * old_fock_b[kid]
+            old_fock_a[kid] = fock_a[kid].copy()
+            old_fock_b[kid] = fock_b[kid].copy()
+
+            # form opdm and orbital gradient (for diis)
+            grad_a[kid] = form_orbital_gradient(basis, Calpha[kid], nalpha, fock_a[kid], kid)
+            grad_b[kid] = form_orbital_gradient(basis, Cbeta[kid], nbeta, fock_b[kid], kid)
+
+        # extrapolate fock matrix
+
+        # solution vector is fock matrix
+        solution_vector = np.zeros(0)
+        for kid in range ( len(basis.kpts) ):
+            solution_vector = np.hstack( (solution_vector, fock_a[kid].flatten(), fock_b[kid].flatten() ) )
+
+        # error vector is orbital gradient
+        error_vector = np.zeros(0)
+        for kid in range ( len(basis.kpts) ):
+            error_vector = np.hstack( (error_vector, grad_a[kid].flatten(), grad_b[kid].flatten() ) )
+
+        # norm of orbital gradient
+        conv = np.linalg.norm(error_vector)
+
+        # extrapolate solution vector
+        new_solution_vector = inner_diis.update(solution_vector, error_vector)
+
+        # reshape solution vector
+        off = 0
+        for kid in range ( len(basis.kpts) ):
+            dim = basis.n_plane_waves_per_k[kid]
+            fock_a[kid] = new_solution_vector[off:off+dim*dim].reshape(fock_a[kid].shape)
+            off += dim*dim
+            fock_b[kid] = new_solution_vector[off:off+dim*dim].reshape(fock_b[kid].shape)
+            off += dim*dim
+
+        one_electron_energy = 0.0
+        coulomb_energy = 0.0
+
+        rho_a = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
+        rho_b = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
+
+        # diagonalize extrapolated fock matrix
+        for kid in range ( len(basis.kpts) ):
+
+            n = nalpha - 1
+            if scf_iter == 0 and guess_mix == True :
+                n = nalpha
+
+            epsilon_alpha, Calpha[kid] = scipy.linalg.eigh(fock_a[kid], eigvals=(0, n))
+            epsilon_beta, Cbeta[kid] = scipy.linalg.eigh(fock_b[kid], eigvals=(0, (nbeta-1)))
+
+            #epsilon_alpha, Calpha = np.linalg.eigh(fock_a)
+            #epsilon_beta, Cbeta = np.linalg.eigh(fock_b)
+
+            # break spin symmetry?
+            if guess_mix is True and scf_iter == 0:
+
+                c = np.cos(0.25 * np.pi)
+                s = np.sin(0.25 * np.pi)
+
+                tmp1 = c * Calpha[kid][:, nalpha-1] - s * Calpha[kid][:, nalpha]
+                tmp2 = s * Calpha[kid][:, nalpha-1] + c * Calpha[kid][:, nalpha]
+
+                Calpha[kid][:, nalpha-1] = tmp1
+                Calpha[kid][:, nalpha] = tmp2
+
+            # update density
+            my_rho_a, occ_alpha = get_density(basis, Calpha[kid], nalpha, kid)
+            my_rho_b, occ_beta = get_density(basis, Cbeta[kid], nbeta, kid)
+
+            # density should be non-negative ...
+            rho_a += my_rho_a.clip(min = 0)
+            rho_b += my_rho_b.clip(min = 0)
+
+            # one-electron part of the energy (alpha)
+            one_electron_energy += get_one_electron_energy(basis, 
+                                                           Calpha[kid], 
+                                                           nalpha, 
+                                                           kid, 
+                                                           v_ne = v_ne)
+
+            # one-electron part of the energy (beta)
+            one_electron_energy += get_one_electron_energy(basis, 
+                                                           Cbeta[kid], 
+                                                           nbeta, 
+                                                           kid, 
+                                                           v_ne = v_ne)
+
+            # coulomb part of the energy: 1/2 J
+            coulomb_energy += get_coulomb_energy(basis, Calpha[kid], nalpha, kid, v_coulomb)
+
+            # coulomb part of the energy: 1/2 J
+            coulomb_energy += get_coulomb_energy(basis, Cbeta[kid], nbeta, kid, v_coulomb)
+
+        rho = rho_a + rho_b
+
+        # coulomb potential
+        tmp = np.fft.ifftn(rho)
+        for myg in range( len(basis.g) ):
+            inner_rhog[myg] = tmp[ get_miller_indices(myg, basis) ]
+
+        v_coulomb = 4.0 * np.pi * np.divide(inner_rhog, basis.g2, out = np.zeros_like(basis.g2), where = basis.g2 != 0.0)
+
+        # exchange-correlation potential
+        if xc != 'hf' :
+
+            v_xc_alpha, v_xc_beta = get_xc_potential(xc, basis, rho_a, rho_b, libxc_x_functional, libxc_c_functional)
+            xc_energy = get_xc_energy(xc, basis, rho_a, rho_b, libxc_x_functional, libxc_c_functional)
+
+        else :
+
+            pass
+
+        # total energy
+        new_total_energy = np.real(one_electron_energy) + np.real(coulomb_energy) + np.real(xc_energy) + enuc
+
+        # convergence in energy
+        energy_diff = np.abs(new_total_energy - old_total_energy)
+
+        # update energy
+        old_total_energy = new_total_energy
+
+        # charge
+        charge = ( basis.omega / ( basis.real_space_grid_dim[0] * basis.real_space_grid_dim[1] * basis.real_space_grid_dim[2] ) ) * np.sum(np.absolute(rho))
+
+        print("    %5i %20.12lf %20.12lf %20.12lf %10.6lf" %  ( scf_iter, new_total_energy, energy_diff, conv, charge ) )
+
+        if ( conv < d_convergence and energy_diff < e_convergence and recompute_exchange) :
             break
 
-        # extrapolate density in outer iterations
-        diff_rhog = inner_rhog - rhog
+        elif ( conv < d_convergence and energy_diff < e_convergence and not recompute_exchange) :
 
-        # TODO: add outer iteration energy convergence check
-        if ( np.linalg.norm(diff_rhog) < d_convergence):
-            break
+            # update exchange matrix for next set of inner iterations
 
-        # update outer density
-        rhog = outer_diis.update(inner_rhog, diff_rhog)
+            # TODO: fix for general k
+            print('')
+            print('        ==> recomputing exchange matrix <==')
+            print('')
+            recompute_exchange = True
+            xc_energy, exchange_matrix_alpha = get_exact_exchange_energy(basis, occ_alpha, nalpha, Calpha, exchange_matrix_alpha, recompute_exchange)
+            if nbeta > 0:
+                my_xc_energy, exchange_matrix_beta = get_exact_exchange_energy(basis, occ_beta, nbeta, Cbeta, exchange_matrix_beta, recompute_exchange)
+                xc_energy += my_xc_energy
+            xc_energy -= 0.5 * (nalpha + nbeta) * madelung
 
-        # update coulomb potential for next set of inner iterations
-        v_coulomb = 4.0 * np.pi * np.divide(rhog, basis.g2, out = np.zeros_like(basis.g2), where = basis.g2 != 0.0)
+            # reset diis ... not sure why this is necessary, but convergence is slow otherwise
+            inner_diis = lib.diis.DIIS()
+            inner_diis.space = diis_dimension
 
-        # update exchange energy and exchange matrix for next set of inner iterations
-        # TODO: fix for general k
-        xc_energy, exchange_matrix_alpha = get_exact_exchange_energy(basis, occ_alpha, nalpha, Calpha)
-        if nbeta > 0:
-            my_xc_energy, exchange_matrix_beta = get_exact_exchange_energy(basis, occ_beta, nbeta, Cbeta)
-            xc_energy += my_xc_energy
-        xc_energy -= 0.5 * (nalpha + nbeta) * madelung
+        else :
+            recompute_exchange = False
 
-    if scf_iter == maxiter - 1 or outer_scf_iter == maxiter - 1 :
+    if scf_iter == maxiter - 1:
         print('')
         print('    UKS iterations did not converge.')
         print('')

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -1089,9 +1089,6 @@ def uks_energy(cell, basis, Calpha, Cbeta, xc = 'lda'):
     else :
         v_ne = get_local_pseudopotential_gth(basis)
 
-    # jellium!
-    #v_ne *= 0.0
-
     # madelung correction
     madelung = tools.pbc.madelung(cell, basis.kpts)
 

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -921,33 +921,30 @@ def uks(cell, basis,
     #    fock_a.append(np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128'))
     #    fock_b.append(np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128'))
 
-    va = 0 * v_ne
-    vb = 0 * v_ne
-    va_old = 0 * v_ne
-    vb_old = 0 * v_ne
+    v_alpha = 0 * v_ne
+    v_beta = 0 * v_ne
+    v_alpha_old = 0 * v_ne
+    v_beta_old = 0 * v_ne
 
     for scf_iter in range(maxiter):
 
         one_electron_energy = 0.0
         coulomb_energy = 0.0
 
-        va_old = va
-        vb_old = vb
-        if xc != 'hf' :
-            va = v_coulomb + v_xc_alpha
-            vb = v_coulomb + v_xc_beta
-        else :
-            va = v_coulomb
-            vb = v_coulomb
+        v_alpha = v_coulomb + v_xc_alpha
+        v_beta = v_coulomb + v_xc_beta
+
+        v_alpha_old = v_alpha
+        v_beta_old = v_beta
 
         # potential in real space
-        va_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
-        va_r.ravel()[flat_idx] = va + v_ne
-        va_r = np.fft.fftn(va_r)
+        v_alpha_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
+        v_alpha_r.ravel()[flat_idx] = v_alpha + v_ne
+        v_alpha_r = np.fft.fftn(v_alpha_r)
 
-        vb_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
-        vb_r.ravel()[flat_idx] = vb + v_ne
-        vb_r = np.fft.fftn(vb_r)
+        v_beta_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
+        v_beta_r.ravel()[flat_idx] = v_beta + v_ne
+        v_beta_r = np.fft.fftn(v_beta_r)
 
         # zero density for this iteration
         rho = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
@@ -998,7 +995,7 @@ def uks(cell, basis,
                     Ki_r *= -4.0 * np.pi / basis.omega
 
                 # action of potential on orbitals in real space, then transform to reciprocal space
-                tmp = va_r * occ_alpha[i] + Ki_r # real space, 3d
+                tmp = v_alpha_r * occ_alpha[i] + Ki_r # real space, 3d
                 tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
                 tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
 
@@ -1030,7 +1027,7 @@ def uks(cell, basis,
                     Ki_r *= -4.0 * np.pi / basis.omega
 
                 # action of potential on orbitals in real space, then transform to reciprocal space
-                tmp = vb_r * occ_beta[i] + Ki_r # real space, 3d
+                tmp = v_beta_r * occ_beta[i] + Ki_r # real space, 3d
                 tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
                 tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
 
@@ -1038,13 +1035,19 @@ def uks(cell, basis,
 
             Fa_c += Vnl @ Calpha[kid][:, :nalpha]
             Fb_c += Vnl @ Cbeta[kid][:, :nbeta]
-            grad_a = Fa_c - epsilon_alpha[kid][np.newaxis, :nalpha] * Calpha[kid][:,:nalpha]
-            grad_b = Fb_c - epsilon_beta[kid][np.newaxis, :nbeta] * Cbeta[kid][:,:nbeta]
+            #grad_a = Fa_c - epsilon_alpha[kid][np.newaxis, :nalpha] * Calpha[kid][:,:nalpha]
+            #grad_b = Fb_c - epsilon_beta[kid][np.newaxis, :nbeta] * Cbeta[kid][:,:nbeta]
+
+            c_Fa_c = Calpha[kid][:, :nalpha].conj().T @ Fa_c
+            c_Fb_c = Cbeta[kid][:, :nbeta].conj().T @ Fb_c
+            grad_a = Fa_c - Calpha[kid][:,:nalpha] @ c_Fa_c
+            grad_b = Fb_c - Cbeta[kid][:,:nbeta] @ c_Fb_c
+
             #print('new way', np.linalg.norm(grad_a), np.linalg.norm(grad_b))
 
             # orbital gradient from [D, F] with the full fock and density matrices
-            #fock_a[kid] = form_fock_matrix(basis, kid, v = va + v_ne) + Vnl + exchange_matrix_alpha
-            #fock_b[kid] = form_fock_matrix(basis, kid, v = vb + v_ne) + Vnl + exchange_matrix_beta
+            #fock_a[kid] = form_fock_matrix(basis, kid, v = v_alpha + v_ne) + Vnl + exchange_matrix_alpha
+            #fock_b[kid] = form_fock_matrix(basis, kid, v = v_beta + v_ne) + Vnl + exchange_matrix_beta
             #Fa_c = fock_a[kid] @ Calpha[kid][:, :nalpha]
             #Fb_c = fock_b[kid] @ Cbeta[kid][:, :nbeta]
             #grad_a = form_orbital_gradient(basis, Calpha[kid], nalpha, fock_a[kid], kid)
@@ -1053,7 +1056,7 @@ def uks(cell, basis,
 
             error_vector = np.hstack( (error_vector, grad_a.flatten(), grad_b.flatten() ) )
 
-        # extrapolate potential
+        # extrapolate coulomb potential
 
         # norm of orbital gradient
         conv = np.linalg.norm(error_vector)
@@ -1062,27 +1065,29 @@ def uks(cell, basis,
         if scf_iter < diis_start_cycle:
 
             # damping?
-            va = (1.0-damp) * va_old + damp * va
-            vb = (1.0-damp) * vb_old + damp * vb
+            v_alpha = (1.0-damp) * v_alpha + damp * v_alpha_old
+            v_beta = (1.0-damp) * v_beta + damp * v_beta_old
 
         else :
 
-            solution_vector = np.hstack( (va, vb) )
-            new_solution_vector = inner_diis.update(solution_vector, error_vector)
-            va = new_solution_vector[:len(va)]
-            vb = new_solution_vector[len(va):]
+            #v_coulomb = inner_diis.update(v_coulomb, error_vector)
 
-        #fock_a[kid] = form_fock_matrix(basis, kid, v = va + v_ne) + Vnl + exchange_matrix_alpha
-        #fock_b[kid] = form_fock_matrix(basis, kid, v = vb + v_ne) + Vnl + exchange_matrix_beta
+            solution_vector = np.hstack( (v_alpha, v_beta) )
+            new_solution_vector = inner_diis.update(solution_vector, error_vector)
+            v_alpha = new_solution_vector[:len(v_alpha)]
+            v_beta = new_solution_vector[len(v_alpha):]
+
+        #fock_a[kid] = form_fock_matrix(basis, kid, v = v_alpha + v_ne) + Vnl + exchange_matrix_alpha
+        #fock_b[kid] = form_fock_matrix(basis, kid, v = v_beta + v_ne) + Vnl + exchange_matrix_beta
 
         # potential in real space
-        va_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
-        va_r.ravel()[flat_idx] = va + v_ne
-        va_r = np.fft.fftn(va_r)
+        v_alpha_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
+        v_alpha_r.ravel()[flat_idx] = v_alpha + v_ne
+        v_alpha_r = np.fft.fftn(v_alpha_r).real
 
-        vb_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
-        vb_r.ravel()[flat_idx] = vb + v_ne
-        vb_r = np.fft.fftn(vb_r)
+        v_beta_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
+        v_beta_r.ravel()[flat_idx] = v_beta + v_ne
+        v_beta_r = np.fft.fftn(v_beta_r).real
 
         one_electron_energy = 0.0
         coulomb_energy = 0.0
@@ -1157,20 +1162,20 @@ def uks(cell, basis,
 
             my_N = nalpha
             occ_list = occ_alpha.copy()
-            my_v_r = va_r.copy()
+            my_v_r = v_alpha_r.copy()
             epsilon_alpha[kid], Calpha[kid] = scipy.sparse.linalg.eigsh(F_C, k=nalpha+1, which="SA")
 
             my_N = nbeta
             occ_list = occ_beta.copy()
-            my_v_r = vb_r.copy()
+            my_v_r = v_beta_r.copy()
             epsilon_beta[kid], Cbeta[kid] = scipy.sparse.linalg.eigsh(F_C, k=nbeta+1, which="SA")
+
+            #epsilon_alpha[kid], Calpha[kid] = scipy.linalg.eigh(fock_a[kid], eigvals=(0, nalpha))
+            #epsilon_beta[kid], Cbeta[kid] = scipy.linalg.eigh(fock_b[kid], eigvals=(0, nbeta))
 
             # why do i need to orthonormalize my orbitals???
             Calpha[kid] = orthonormalize(Calpha[kid])
             Cbeta[kid] = orthonormalize(Cbeta[kid])
-
-            #epsilon_alpha, Calpha[kid] = scipy.linalg.eigh(fock_a[kid], eigvals=(0, n))
-            #epsilon_beta, Cbeta[kid] = scipy.linalg.eigh(fock_b[kid], eigvals=(0, (nbeta-1)))
 
             #epsilon_alpha, Calpha = np.linalg.eigh(fock_a)
             #epsilon_beta, Cbeta = np.linalg.eigh(fock_b)
@@ -1232,7 +1237,7 @@ def uks(cell, basis,
 
         else :
 
-            # we'll deal with hf exchange matrices below ... here, just get the energy
+            # we'll deal with hf exchange matrices on the fly ... here, just get the energy
             xc_energy, exchange_matrix_alpha = get_exact_exchange_energy(basis, occ_alpha, nalpha, Calpha, exchange_matrix_alpha, False)
             if nbeta > 0:
                 my_xc_energy, exchange_matrix_beta = get_exact_exchange_energy(basis, occ_beta, nbeta, Cbeta, exchange_matrix_beta, False)

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -673,7 +673,7 @@ def get_coulomb_energy(basis, C, N, kid, v_coulomb):
 
 def fock_on_orbitals(basis, kid, ne, nmo, occ, C, T, v_r, Vnl, xc):
     """
-    evaluate action of fock matrix on orbitals
+    evaluate action of fock matrix on orbitals and build ace operator
 
     :param basis: the plane wave basis object
     :param kid: the current k-point
@@ -691,7 +691,6 @@ def fock_on_orbitals(basis, kid, ne, nmo, occ, C, T, v_r, Vnl, xc):
     :return Ki: exchange operator acting on orbitals, i, in reciprocal space
     :return exchange: the exchange matrix
     """
-
 
     Kij_G = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
     Ki = np.zeros((basis.n_plane_waves_per_k[kid], nmo), dtype='complex128')
@@ -741,6 +740,90 @@ def fock_on_orbitals(basis, kid, ne, nmo, occ, C, T, v_r, Vnl, xc):
         exchange[:,i] = tmp[basis.kg_to_g[kid]] # map last term to small flattened basis
 
     return F_c, Ki, exchange
+
+def fock_on_orbitals_using_ace(basis, kid, ne, nmo, occ, c, T, v_r, Vnl, xc, Ki, B_ace, ace_exchange):
+    """
+    apply fock operator to a set of orbitals using the ace operator
+
+    :param basis: the plane wave basis object
+    :param kid: the current k-point
+    :param ne: number of electrons
+    :param nmo: number of bands (could be larger than ne)
+    :param occ: occupied orbitals, in real space
+    :param C: occupied orbitals, in reciprocal space
+    :param T: diagonal of the kinetic energy matrix, in reciprocal space
+    :param v_r: the potential (coulomb + local pseudopotential + xc), in real space
+    :param Vnl: matrix representation of non-local pseudopotential, in reciprocal space
+    :param xc: the exchange-correlation functional
+    :param Ki: exchange operator acting on orbitals, i, in reciprocal space
+    :param B: ACE B matrix
+    :param ace_exchange: do use the ace operator for exchange?
+
+    :return F @ c: action of fock operator on the orbitals in reciprococal space
+    """
+
+    # orbital in real space
+    occ = np.zeros([np.prod(basis.real_space_grid_dim), c.shape[1]], dtype=np.complex128) # lobpcg
+    occ[basis.grid_idx_k[kid]] = c
+    occ = occ.reshape(basis.real_space_grid_dim)
+    occ = np.fft.fftn(occ) 
+
+    # exchange
+    Ki_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
+    if xc == 'hf' and not ace_exchange:
+        for j in range(0, ne):
+
+            # Cij(r') = phi_i(r') phi_j*(r')
+            # Cij(g) = FFT[Cij(r')]
+            tmp = np.fft.ifftn(occ_list[j].conj() * occ)
+            Cij = tmp.ravel()[basis.flat_idx]
+
+            # Kij(g) = Cij(g) * FFT[1/|r-r'|]
+            Kij_G.ravel()[basis.flat_idx] = Cij * basis.inv_g2 #Kij
+
+            # Kij(r) = FFT^-1[Kij(g)]
+            Kij_r = np.fft.fftn(Kij_G)
+
+            # action of K on an occupied orbital, i: 
+            # Ki(r) = sum_j Kij(r) phi_j(r)
+            Ki_r += Kij_r * occ_list[j]
+
+        Ki_r *= -4.0 * np.pi / basis.omega
+
+    # action of potential on orbitals in real space, then transform to reciprocal space
+    tmp = v_r * occ  # real space, 3d
+    tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
+    tmp = tmp.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
+    tmp = tmp[basis.kg_to_g[kid]] # reciprocal space, small flattened basis
+    tmp = tmp.reshape(c.shape) # for lobpcg
+
+    #F_c = T[kid] * c + tmp + Vnl @ c # eigsh
+    F_c = T[kid][:, None] * c + tmp + Vnl @ c # lobpcg
+
+    if xc == 'hf':
+        if ace_exchange :
+
+            # (< phi_j | K) | c >
+            tmp = Ki.conj().T @ c
+            # sum_j B_{ij} < phi_j | K | c > 
+            tmp = B_ace @ tmp 
+            # sum_i K | phi_i >  B_{ij} < phi_j | K | c >
+            ace = Ki @ tmp 
+
+            F_c += ace
+ 
+        else :
+
+            tmp = Ki_r # real space, 3d
+            tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
+            tmp = tmp.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
+            tmp = tmp[basis.kg_to_g[kid]] # reciprocal space, small flattened basis
+            tmp = tmp.reshape(c.shape) # for lobpcg
+            F_c += tmp
+
+    #print(np.linalg.norm(ace - tmp))
+
+    return F_c
 
 def build_B_ace(ne, nmo, C, Ki, exchange):
     """
@@ -836,6 +919,7 @@ def compute_local_potentials(rho_alpha, rho_beta, v_ne, basis, xc, libxc_x_funct
     v_beta_r = np.fft.fftn(v_beta_r).real
 
     return v_coulomb, v_alpha_r, v_beta_r
+
 def uks(cell, basis, 
         xc = 'lda', 
         guess_mix = False, 
@@ -955,7 +1039,7 @@ def uks(cell, basis,
         print("    ==> WARNING <==")
         print("")
         print("        guess_mix = True is not working and is currently disabled")
- 
+
     print("")
     print("    ==> Begin UKS Iterations <==")
     print("")
@@ -1134,100 +1218,19 @@ def uks(cell, basis,
             if jellium:
                 Vnl *= 0.0
 
-            def apply_fock_operator_to_orbital(c):
-                """
-                apply fock operator to an orbital. note that the function depends on 
-                some parameters not passed in as argumnets
+            def lobpcg_alpha(c):
+                return fock_on_orbitals_using_ace(basis, kid, nalpha, nmo_alpha, occ_alpha, c, T, v_alpha_r, Vnl, xc, Ki_alpha[kid], B_alpha_ace[kid], ace_exchange)
 
-                :param c: orbital in reciprococal space
-                :return F @ c: action of fock operator on the orbital in reciprococal space
-
-                :implicit parameter my_N: the number of electrons of the same spin as orbital c 
-                :implicit parameter occ_list: a list of occupied orbitals in real space with the same spin as orbital c
-                :implicit parameter my_v_r: the potential in real space experienced by orbital c (excluding exchange)
-                """
-
-                # orbital in real space
-                #occ = np.zeros(np.prod(grid_shape), dtype=np.complex128) # eigsh
-                occ = np.zeros([np.prod(basis.real_space_grid_dim), c.shape[1]], dtype=np.complex128) # lobpcg
-                occ[basis.grid_idx_k[kid]] = c
-                occ = occ.reshape(basis.real_space_grid_dim)
-                occ = np.fft.fftn(occ) 
-
-                # exchange
-                Ki_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
-                if xc == 'hf' and not ace_exchange:
-                    for j in range(0, my_N):
-
-                        # Cij(r') = phi_i(r') phi_j*(r')
-                        # Cij(g) = FFT[Cij(r')]
-                        tmp = np.fft.ifftn(occ_list[j].conj() * occ)
-                        Cij = tmp.ravel()[basis.flat_idx]
-
-                        # Kij(g) = Cij(g) * FFT[1/|r-r'|]
-                        Kij_G.ravel()[basis.flat_idx] = Cij * basis.inv_g2 #Kij
-
-                        # Kij(r) = FFT^-1[Kij(g)]
-                        Kij_r = np.fft.fftn(Kij_G)
-
-                        # action of K on an occupied orbital, i: 
-                        # Ki(r) = sum_j Kij(r) phi_j(r)
-                        Ki_r += Kij_r * occ_list[j]
-
-                    Ki_r *= -4.0 * np.pi / basis.omega
-
-                # action of potential on orbitals in real space, then transform to reciprocal space
-                tmp = my_v_r * occ  # real space, 3d
-                tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
-                tmp = tmp.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
-                tmp = tmp[basis.kg_to_g[kid]] # reciprocal space, small flattened basis
-                tmp = tmp.reshape(c.shape) # for lobpcg
-
-                #F_c = T[kid] * c + tmp + Vnl @ c # eigsh
-                F_c = T[kid][:, None] * c + tmp + Vnl @ c # lobpcg
-
-                # ace
-
-                # (< phi_j | K) | c >
-                tmp = my_Ki.conj().T @ c
-                # sum_j B_{ij} < phi_j | K | c > 
-                tmp = my_B @ tmp 
-                # sum_i K | phi_i >  B_{ij} < phi_j | K | c >
-                ace = my_Ki @ tmp 
-
-                if ace_exchange :
-                    F_c += ace
-
-                # exact exchange
-                if not ace_exchange :
-                    tmp = Ki_r # real space, 3d
-                    tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
-                    tmp = tmp.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
-                    tmp = tmp[basis.kg_to_g[kid]] # reciprocal space, small flattened basis
-                    tmp = tmp.reshape(c.shape) # for lobpcg
-
-                    F_c += tmp
-
-                #print(np.linalg.norm(ace - tmp))
-
-                return F_c
-
-            F_C = LinearOperator((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), matvec=apply_fock_operator_to_orbital, dtype='complex128')
+            def lobpcg_beta(c):
+                return fock_on_orbitals_using_ace(basis, kid, nbeta, nmo_beta, occ_beta, c, T, v_beta_r, Vnl, xc, Ki_beta[kid], B_beta_ace[kid], ace_exchange)
 
             if not jellium:
-                my_N = nalpha
-                occ_list = occ_alpha.copy()
-                my_v_r = v_alpha_r.copy()
-                my_Ki = Ki_alpha[kid].copy()
-                my_B = B_alpha_ace[kid].copy()
-                epsilon_alpha[kid], Calpha[kid] = scipy.sparse.linalg.lobpcg(F_C, Calpha[kid], largest=False, maxiter=2000, tol=d_convergence*0.1)
 
-                my_N = nbeta
-                occ_list = occ_beta.copy()
-                my_v_r = v_beta_r.copy()
-                my_Ki = Ki_beta[kid].copy()
-                my_B = B_beta_ace[kid].copy()
-                epsilon_beta[kid], Cbeta[kid] = scipy.sparse.linalg.lobpcg(F_C, Cbeta[kid], largest=False, maxiter=2000, tol=d_convergence*0.1)
+                Fa_C = LinearOperator((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), matvec=lobpcg_alpha, dtype='complex128')
+                Fb_C = LinearOperator((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), matvec=lobpcg_beta, dtype='complex128')
+
+                epsilon_alpha[kid], Calpha[kid] = scipy.sparse.linalg.lobpcg(Fa_C, Calpha[kid], largest=False, maxiter=2000, tol=d_convergence*0.1)
+                epsilon_beta[kid], Cbeta[kid] = scipy.sparse.linalg.lobpcg(Fb_C, Cbeta[kid], largest=False, maxiter=2000, tol=d_convergence*0.1)
 
             else :
                 epsilon_alpha[kid], Calpha[kid] = scipy.linalg.eigh(np.diag(T[kid]), eigvals=(0, nalpha))
@@ -1242,8 +1245,8 @@ def uks(cell, basis,
             #    tmp1 = c * Calpha[kid][:, nalpha-1] - s * Calpha[kid][:, nalpha]
             #    tmp2 = s * Calpha[kid][:, nalpha-1] + c * Calpha[kid][:, nalpha]
 
-            #    Calpha[kid][:, nalpha-1] = tmp1
-            #    Calpha[kid][:, nalpha] = tmp2
+            #    Calpha[kid][:, nalpha-1] = tmp1.copy()
+            #    Calpha[kid][:, nalpha] = tmp2.copy()
 
             # why do i need to orthonormalize my orbitals???
             Calpha[kid] = orthonormalize(Calpha[kid])

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -782,6 +782,60 @@ def build_B_ace(ne, nmo, C, Ki, exchange):
 
     return B_ace
 
+def compute_local_potentials(rho_alpha, rho_beta, v_ne, basis, xc, libxc_x_functional, libxc_c_functional, jellium):
+    """
+    compute local potentials (coulomb + local pseudopotential + xc)
+
+    :param rho_alpha: the alpha-spin density
+    :param rho_beta: the beta-spin density
+    :param v_ne: the external potential or local pseudopotential
+    :param basis: the plane wave basis object
+    :param xc: the name of the exchange-correlation potential
+    :param libxc_x_functional: the libxc exchange functional
+    :param libxc_c_functional: the libxc correlation functional
+    :param jellium: are we modeling jellium?
+
+    :return v_coulomb: the coulomb potential in reciprocal space
+    :return v_alpha_r: the alpha-spin local potential in real space
+    :return v_beta_r: the beta-spin local potential in real space
+    """
+
+    # coulomb potential
+    tmp = np.fft.ifftn(rho_alpha + rho_beta)
+    rhog = np.zeros(len(basis.g), dtype = 'complex128')
+    for myg in range( len(basis.g) ):
+        rhog[myg] = tmp[ get_miller_indices(myg, basis) ]
+
+    v_coulomb = 4.0 * np.pi * rhog * basis.inv_g2
+
+    # jellium ... but only true in the thermodynamic limit
+    if jellium:
+        v_coulomb *= 0.0
+
+    # alpha- and beta-spin local potentials
+    v_alpha = v_coulomb.copy()
+    v_beta = v_coulomb.copy()
+
+    # exchange-correlation potential
+    if xc != 'hf' :
+
+        v_xc_alpha, v_xc_beta = get_xc_potential(xc, basis, rho_alpha, rho_beta, libxc_x_functional, libxc_c_functional)
+        xc_energy = get_xc_energy(xc, basis, rho_alpha, rho_beta, libxc_x_functional, libxc_c_functional)
+
+        v_alpha += v_xc_alpha
+        v_beta +=  v_xc_beta
+
+    # alpha-spin potential in real space
+    v_alpha_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
+    v_alpha_r.ravel()[basis.flat_idx] = v_alpha + v_ne
+    v_alpha_r = np.fft.fftn(v_alpha_r).real
+
+    # beta-spin potential in real space
+    v_beta_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
+    v_beta_r.ravel()[basis.flat_idx] = v_beta + v_ne
+    v_beta_r = np.fft.fftn(v_beta_r).real
+
+    return v_coulomb, v_alpha_r, v_beta_r
 def uks(cell, basis, 
         xc = 'lda', 
         guess_mix = False, 
@@ -867,7 +921,7 @@ def uks(cell, basis,
         nbeta = jellium_ne // 2
         enuc = 0.0
 
-    # damp fock matrix (helps with convergence sometimes)
+    # damp density (helps with convergence sometimes)
     damping_factor = 1.0
     if damp_density :
         damping_factor = 0.8
@@ -875,9 +929,10 @@ def uks(cell, basis,
     # diis 
     diis_start_cycle = damping_iterations
 
-    rs = (3 * basis.omega / ( 4.0 * np.pi * (nalpha + nbeta)))**(1.0/3.0)
     print("")
-    print('    Wigner-Seitz radius (rs)                     %20.12f' % (rs))
+    if jellium:
+        rs = (3 * basis.omega / ( 4.0 * np.pi * (nalpha + nbeta)))**(1.0/3.0)
+        print('    Wigner-Seitz radius (rs)                     %20.12f' % (rs))
     print('    exchange functional:                         %20s' % ( functional_name_dict[xc][0] ) )
     print('    correlation functional:                      %20s' % ( functional_name_dict[xc][1] ) )
     print('    e_convergence:                               %20.2e' % ( e_convergence ) )
@@ -901,7 +956,6 @@ def uks(cell, basis,
         print("")
         print("        guess_mix = True is not working and is currently disabled")
  
-
     print("")
     print("    ==> Begin UKS Iterations <==")
     print("")
@@ -935,18 +989,17 @@ def uks(cell, basis,
 
     for kid in range ( len(basis.kpts) ):
 
-        Calpha.append(np.random.rand(basis.n_plane_waves_per_k[kid], nmo_alpha) * 1e-3)
-        Cbeta.append(np.random.rand(basis.n_plane_waves_per_k[kid], nmo_beta) * 1e-3)
-        #Calpha.append(np.zeros((basis.n_plane_waves_per_k[kid], nmo), dtype='complex128'))
-        #Cbeta.append(np.zeros((basis.n_plane_waves_per_k[kid], nmo), dtype='complex128'))
+        Calpha.append(np.random.rand(basis.n_plane_waves_per_k[kid], nmo_alpha) * 1e-8)
+        Cbeta.append(np.random.rand(basis.n_plane_waves_per_k[kid], nmo_beta) * 1e-8)
+        #Calpha.append(np.zeros((basis.n_plane_waves_per_k[kid], nmo_alpha), dtype='complex128'))
+        #Cbeta.append(np.zeros((basis.n_plane_waves_per_k[kid], nmo_beta), dtype='complex128'))
         for i in range (nmo_alpha):
             Calpha[kid][i, i] = 1.0
         for i in range (nmo_beta):
             Cbeta[kid][i, i] = 1.0
         Calpha[kid] = orthonormalize(Calpha[kid])
-        #Cbeta[kid] = orthonormalize(Cbeta[kid])
-        Cbeta[kid] = Calpha[kid].copy()
-
+        Cbeta[kid] = orthonormalize(Cbeta[kid])
+        #Cbeta[kid] = Calpha[kid].copy()
 
         B_alpha_ace.append(np.zeros((nmo_alpha, nmo_alpha), dtype='complex128'))
         B_beta_ace.append(np.zeros((nmo_beta, nmo_beta), dtype='complex128'))
@@ -957,7 +1010,26 @@ def uks(cell, basis,
         epsilon_alpha.append(np.zeros((nmo_alpha), dtype='complex128'))
         epsilon_beta.append(np.zeros((nmo_beta), dtype='complex128'))
 
-    # diis extrapolates fock matrix
+    # initialize occ_alpha and occ_beta arrays ... won't work for kpts > 0
+    rho_a, occ_alpha = get_density(basis, Calpha[0], nalpha, nmo_alpha, kid)
+    rho_b, occ_beta = get_density(basis, Cbeta[0], nbeta, nmo_beta, kid)
+
+    # kinetic energy
+    T = []
+    for kid in range ( len(basis.kpts) ):
+        kgtmp = basis.kpts[kid] + basis.g[basis.kg_to_g[kid, :basis.n_plane_waves_per_k[kid]]]
+        T.append(np.einsum('ij,ij->i', kgtmp, kgtmp) / 2.0)
+
+    # jellium guess
+    rho_alpha = nalpha / basis.omega * np.ones(basis.real_space_grid_dim, dtype = 'float64')
+    rho_beta = nbeta / basis.omega * np.ones(basis.real_space_grid_dim, dtype = 'float64')
+    rho_alpha_old = rho_alpha.copy()
+    rho_beta_old = rho_beta.copy()
+
+    # local potentials
+    v_coulomb, v_alpha_r, v_beta_r = compute_local_potentials(rho_alpha, rho_beta, v_ne, basis, xc, libxc_x_functional, libxc_c_functional, jellium)
+
+    # diis extrapolates the alpha- and beta-spin densities
     from pyscf import lib
     diis = lib.diis.DIIS()
     diis.space = diis_dimension
@@ -967,87 +1039,22 @@ def uks(cell, basis,
     scf_iter = 0 # initialize variable incase maxiter = 0
     one_electron_energy = 0.0
     coulomb_energy = 0.0
-    recompute_exchange = True
-
-    # so we have occ_alpha and occ_beta arrays ... won't work for kpts > 0
-    my_rho_a, occ_alpha = get_density(basis, Calpha[0], nalpha, nmo_alpha, kid)
-    my_rho_b, occ_beta = get_density(basis, Cbeta[0], nbeta, nmo_beta, kid)
-
-    # kinetic energy
-    T = []
-    for kid in range ( len(basis.kpts) ):
-        kgtmp = basis.kpts[kid] + basis.g[basis.kg_to_g[kid, :basis.n_plane_waves_per_k[kid]]]
-        T.append(np.einsum('ij,ij->i', kgtmp, kgtmp) / 2.0)
-
-        #epsilon_alpha, Calpha[kid] = scipy.linalg.eigh(np.diag(T[kid]), eigvals=(0, nmo-1))
-        #Calpha[kid] = orthonormalize(Calpha[kid])
-        #Cbeta[kid] = Calpha[kid].copy()
-
-    #print(2*np.sum(np.sort(T[0])[:nalpha]))
-    #exit()
-
-    v_alpha = 0 * v_ne
-    v_beta = 0 * v_ne
-
-    # jellium guess
-    rho_alpha = nalpha / basis.omega * np.ones(basis.real_space_grid_dim, dtype = 'float64')
-    rho_beta = nbeta / basis.omega * np.ones(basis.real_space_grid_dim, dtype = 'float64')
-    rho_alpha_old = rho_alpha.copy()
-    rho_beta_old = rho_beta.copy()
-
-    # potentials
-    rho = rho_alpha + rho_beta
-
-    # coulomb potential
-    tmp = np.fft.ifftn(rho)
-    for myg in range( len(basis.g) ):
-        rhog[myg] = tmp[ get_miller_indices(myg, basis) ]
-
-    v_coulomb = 4.0 * np.pi * rhog * basis.inv_g2
-
-    # jellium ... but only true in the thermodynamic limit
-    if jellium:
-        v_coulomb *= 0.0
-
-    # exchange-correlation potential
-    v_xc_alpha = np.zeros(len(basis.g), dtype = 'complex128')
-    v_xc_beta = np.zeros(len(basis.g), dtype = 'complex128')
-    if xc != 'hf' :
-
-        v_xc_alpha, v_xc_beta = get_xc_potential(xc, basis, rho_alpha, rho_beta, libxc_x_functional, libxc_c_functional)
-        xc_energy = get_xc_energy(xc, basis, rho_alpha, rho_beta, libxc_x_functional, libxc_c_functional)
-
-    v_alpha = v_coulomb + v_xc_alpha
-    v_beta = v_coulomb + v_xc_beta
 
     for scf_iter in range(maxiter):
 
         one_electron_energy = 0.0
         coulomb_energy = 0.0
 
-        v_alpha = v_coulomb + v_xc_alpha
-        v_beta = v_coulomb + v_xc_beta
-
-        # potential in real space
-        v_alpha_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
-        v_alpha_r.ravel()[basis.flat_idx] = v_alpha + v_ne
-        v_alpha_r = np.fft.fftn(v_alpha_r).real
-
-        v_beta_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
-        v_beta_r.ravel()[basis.flat_idx] = v_beta + v_ne
-        v_beta_r = np.fft.fftn(v_beta_r).real
-
-        # zero density for this iteration
-        rho = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
+        # compute local potentials
+        v_coulomb, v_alpha_r, v_beta_r = compute_local_potentials(rho_alpha, rho_beta, v_ne, basis, xc, libxc_x_functional, libxc_c_functional, jellium)
 
         # damping factor
         damp = 1.0
         if scf_iter < diis_start_cycle and damp_density : 
             damp = damping_factor
 
-        # orbital gradient
+        # evaluate the orbital gradient
         error_vector = np.zeros(0)
-
         for kid in range( len(basis.kpts) ):
 
             # TODO: don't store non-local pseudopotential in the planewave basis
@@ -1084,7 +1091,7 @@ def uks(cell, basis,
 
             error_vector = np.hstack( (error_vector, grad_a.flatten(), grad_b.flatten() ) )
 
-        # norm of orbital gradient
+        # norm of the orbital gradient for convergence check
         conv = np.linalg.norm(error_vector)
 
         # damp or extrapolate density or potential
@@ -1104,37 +1111,8 @@ def uks(cell, basis,
         rho_alpha.clip(min = 0)
         rho_beta.clip(min = 0)
 
-        # recompute potentials
-        rho = rho_alpha + rho_beta
-
-        # coulomb potential
-        tmp = np.fft.ifftn(rho)
-        for myg in range( len(basis.g) ):
-            rhog[myg] = tmp[ get_miller_indices(myg, basis) ]
-
-        v_coulomb = 4.0 * np.pi * rhog * basis.inv_g2
-
-        # jellium ... but only true in the thermodynamic limit
-        if jellium:
-            v_coulomb *= 0.0
-
-        # exchange-correlation potential
-        if xc != 'hf' :
-
-            v_xc_alpha, v_xc_beta = get_xc_potential(xc, basis, rho_alpha, rho_beta, libxc_x_functional, libxc_c_functional)
-            xc_energy = get_xc_energy(xc, basis, rho_alpha, rho_beta, libxc_x_functional, libxc_c_functional)
-
-        v_alpha = v_coulomb + v_xc_alpha
-        v_beta = v_coulomb + v_xc_beta
-    
-        # potential in real space
-        v_alpha_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
-        v_alpha_r.ravel()[basis.flat_idx] = v_alpha + v_ne
-        v_alpha_r = np.fft.fftn(v_alpha_r).real
-
-        v_beta_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
-        v_beta_r.ravel()[basis.flat_idx] = v_beta + v_ne
-        v_beta_r = np.fft.fftn(v_beta_r).real
+        # recompute potentials after damping / diis extrapolation
+        v_coulomb, v_alpha_r, v_beta_r = compute_local_potentials(rho_alpha, rho_beta, v_ne, basis, xc, libxc_x_functional, libxc_c_functional, jellium)
 
         one_electron_energy = 0.0
         coulomb_energy = 0.0
@@ -1303,23 +1281,8 @@ def uks(cell, basis,
             # coulomb part of the energy: 1/2 J
             coulomb_energy += get_coulomb_energy(basis, Cbeta[kid], nbeta, kid, v_coulomb)
 
-        rho = rho_alpha + rho_beta
-
-        # coulomb potential
-        tmp = np.fft.ifftn(rho)
-        for myg in range( len(basis.g) ):
-            rhog[myg] = tmp[ get_miller_indices(myg, basis) ]
-
-        v_coulomb = 4.0 * np.pi * rhog * basis.inv_g2
-
-        # jellium ... but only true in the thermodynamic limit
-        if jellium:
-            v_coulomb *= 0.0
-
-        # exchange-correlation potential
+        # exchange-correlation energy
         if xc != 'hf' :
-
-            v_xc_alpha, v_xc_beta = get_xc_potential(xc, basis, rho_alpha, rho_beta, libxc_x_functional, libxc_c_functional)
             xc_energy = get_xc_energy(xc, basis, rho_alpha, rho_beta, libxc_x_functional, libxc_c_functional)
 
         else :
@@ -1346,7 +1309,7 @@ def uks(cell, basis,
         old_total_energy = new_total_energy
 
         # charge
-        charge = ( basis.omega / ( basis.real_space_grid_dim[0] * basis.real_space_grid_dim[1] * basis.real_space_grid_dim[2] ) ) * np.sum(np.absolute(rho))
+        charge = ( basis.omega / ( basis.real_space_grid_dim[0] * basis.real_space_grid_dim[1] * basis.real_space_grid_dim[2] ) ) * np.sum(np.absolute(rho_alpha + rho_beta))
 
         if jellium:
             print("    %5i %20.12lf %20.12lf %20.12lf %10.6lf %20.12f %20.12f %20.12f %20.12f %20.12f" %  ( scf_iter, new_total_energy, energy_diff, conv, charge, np.linalg.norm(Calpha[kid] - Cbeta[kid]), np.real(one_electron_energy), np.real(coulomb_energy), np.real(xc_energy), -0.5 * (nalpha + nbeta) * madelung))

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -48,7 +48,7 @@ def orthonormalize(C):
     # apply to orbitals
     return C @ S_inv_sqrt
 
-def get_exact_exchange_energy(basis, occupied_orbitals, N, C):
+def get_exact_exchange_energy(basis, phi_r, N, C, occupation_numbers):
     """
 
     evaluate the exact Hartree-Fock exchange energy, according to
@@ -62,9 +62,10 @@ def get_exact_exchange_energy(basis, occupied_orbitals, N, C):
     see JCP 108, 4697 (1998) for more details.
 
     :param basis: plane wave basis information
-    :param occupied_orbitals: a list of occupied orbitals
-    :param N: the number of electrons
-    :param N: the MO transformation matrix
+    :param phi_r: a list of occupied orbitals in real space
+    :param N: the number of orbitals (could be greater than number of electrons with the use of the occupation_numbers list)
+    :param C: the MO transformation matrix
+    :param occupation_numbers: a list of occupation numbers (0, 1, or fermi-dirac for smearing)
 
     :return exchange_energy: the exact Hartree-Fock exchange energy
 
@@ -78,7 +79,7 @@ def get_exact_exchange_energy(basis, occupied_orbitals, N, C):
 
             # Cij(r') = phi_i(r') phi_j*(r')
             # Cij(g) = FFT[Cij(r')]
-            tmp = np.fft.ifftn(occupied_orbitals[j].conj() * occupied_orbitals[i])
+            tmp = np.fft.ifftn(phi_r[j].conj() * phi_r[i]) * occupation_numbers[i] * occupation_numbers[j]
             Cij = tmp.ravel()[basis.flat_idx]
 
             # Kij(g) = Cij(g) * FFT[1/|r-r'|]
@@ -397,7 +398,7 @@ def get_nuclear_electronic_potential(cell, basis, valence_charges = None):
 
     return vneG
 
-def get_density(basis, C, Ne, Nmo, kid):
+def get_density(basis, C, Ne, Nmo, kid, occupation_numbers):
     """
 
     get real-space density from molecular orbital coefficients
@@ -407,30 +408,30 @@ def get_density(basis, C, Ne, Nmo, kid):
     :param Ne: the number of electrons
     :param Nmo: the number of molecular orbitals (Nmo >= Ne)
     :param kid: index for a given k-point
+    :param occupation_numbers: a list of occupation numbers (0, 1, or fermi-dirac for smearing)
 
     :return rho: the density
-    :return orbitals_r: the molecular orbitals in real space 
+    :return phi_r: the molecular orbitals in real space 
 
     """
 
-    orbitals_r = []
+    phi_r = []
     rho = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
     for pp in range(Nmo):
 
-        occ = np.zeros(basis.real_space_grid_dim,dtype = 'complex128')
+        phi = np.zeros(basis.real_space_grid_dim,dtype = 'complex128')
 
         for tt in range( basis.n_plane_waves_per_k[kid] ):
 
             ik = basis.kg_to_g[kid][tt]
-            occ[ get_miller_indices(ik, basis) ] = C[tt, pp]
+            phi[ get_miller_indices(ik, basis) ] = C[tt, pp]
 
-        occ = np.fft.fftn(occ) 
-        orbitals_r.append(occ)
+        phi = np.fft.fftn(phi) 
+        phi_r.append(phi)
 
-        if pp < Ne:
-            rho += np.absolute(occ)**2.0 / basis.omega
+        rho += np.absolute(phi)**2.0 / basis.omega * occupation_numbers[pp]**2
 
-    return ( 1.0 / len(basis.kpts) ) * rho, orbitals_r
+    return ( 1.0 / len(basis.kpts) ) * rho, phi_r
 
 # TODO: eliminate npw x npw storage
 def get_nonlocal_pp_energy(basis, C, N, kid):
@@ -465,7 +466,7 @@ def get_nonlocal_pp_energy(basis, C, N, kid):
 
     return nonlocal_pp_energy
 
-def fock_on_orbitals(basis, kid, ne, nmo, occ, C, T, v_r, Vnl, xc):
+def fock_on_orbitals(basis, kid, ne, nmo, phi_r, C, T, v_r, Vnl, xc, occupation_numbers):
     """
     evaluate action of fock matrix on orbitals and build ace operator
 
@@ -473,12 +474,13 @@ def fock_on_orbitals(basis, kid, ne, nmo, occ, C, T, v_r, Vnl, xc):
     :param kid: the current k-point
     :param ne: number of electrons
     :param nmo: number of bands (could be larger than ne)
-    :param occ: occupied orbitals, in real space
-    :param C: occupied orbitals, in reciprocal space
+    :param phi_r: orbitals, in real space
+    :param C: orbitals, in reciprocal space
     :param T: diagonal of the kinetic energy matrix, in reciprocal space
     :param v_r: the potential (coulomb + local pseudopotential + xc), in real space
     :param Vnl: matrix representation of non-local pseudopotential, in reciprocal space
     :param xc: the exchange-correlation functional
+    :param occupation_numbers: a list of occupation numbers (0, 1, or fermi-dirac for smearing)
 
 
     :return F_c: the action of the fock matrix on the orbials
@@ -495,11 +497,11 @@ def fock_on_orbitals(basis, kid, ne, nmo, occ, C, T, v_r, Vnl, xc):
         # exchange
         Ki_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
         if xc == 'hf':
-            for j in range(0, ne):
+            for j in range(0, nmo): # note, this has changed from ne to nmo with the introduction of occupation_numbers
 
                 # Cij(r') = phi_i(r') phi_j*(r')
                 # Cij(g) = FFT[Cij(r')]
-                tmp = np.fft.ifftn(occ[j].conj() * occ[i])
+                tmp = np.fft.ifftn(phi_r[j].conj() * phi_r[i])
                 Cij = tmp.ravel()[basis.flat_idx]
 
                 # Kij(g) = Cij(g) * FFT[1/|r-r'|]
@@ -510,12 +512,12 @@ def fock_on_orbitals(basis, kid, ne, nmo, occ, C, T, v_r, Vnl, xc):
 
                 # action of K on an occupied orbital, i: 
                 # Ki(r) = sum_j Kij(r) phi_j(r)
-                Ki_r += Kij_r * occ[j]
+                Ki_r += Kij_r * phi_r[j] * occupation_numbers[j]
 
             Ki_r *= -4.0 * np.pi / basis.omega
 
         # action of potential on orbitals in real space, then transform to reciprocal space
-        tmp = v_r * occ[i] #+ Ki_r # real space, 3d
+        tmp = v_r * phi_r[i] #+ Ki_r # real space, 3d
         tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
         tmp = tmp.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
 
@@ -535,7 +537,7 @@ def fock_on_orbitals(basis, kid, ne, nmo, occ, C, T, v_r, Vnl, xc):
 
     return F_c, Ki, exchange
 
-def fock_on_orbitals_using_ace(basis, kid, ne, nmo, occ, c, T, v_r, Vnl, xc, Ki, B_ace, ace_exchange):
+def fock_on_orbitals_using_ace(basis, kid, ne, nmo, phi_r, c, T, v_r, Vnl, xc, Ki, B_ace, ace_exchange, occupation_numbers):
     """
     apply fock operator to a set of orbitals using the ace operator
 
@@ -543,8 +545,8 @@ def fock_on_orbitals_using_ace(basis, kid, ne, nmo, occ, c, T, v_r, Vnl, xc, Ki,
     :param kid: the current k-point
     :param ne: number of electrons
     :param nmo: number of bands (could be larger than ne)
-    :param occ: occupied orbitals, in real space
-    :param C: occupied orbitals, in reciprocal space
+    :param phi_r: orbitals, in real space
+    :param C: orbitals, in reciprocal space
     :param T: diagonal of the kinetic energy matrix, in reciprocal space
     :param v_r: the potential (coulomb + local pseudopotential + xc), in real space
     :param Vnl: matrix representation of non-local pseudopotential, in reciprocal space
@@ -552,24 +554,26 @@ def fock_on_orbitals_using_ace(basis, kid, ne, nmo, occ, c, T, v_r, Vnl, xc, Ki,
     :param Ki: exchange operator acting on orbitals, i, in reciprocal space
     :param B: ACE B matrix
     :param ace_exchange: do use the ace operator for exchange?
+    :param occupation_numbers: a list of occupation numbers (0, 1, or fermi-dirac for smearing)
 
     :return F @ c: action of fock operator on the orbitals in reciprococal space
     """
 
     # orbital in real space
-    occ = np.zeros([np.prod(basis.real_space_grid_dim), c.shape[1]], dtype=np.complex128) # lobpcg
-    occ[basis.grid_idx_k[kid]] = c
-    occ = occ.reshape(basis.real_space_grid_dim)
-    occ = np.fft.fftn(occ) 
+    current_phi = np.zeros([np.prod(basis.real_space_grid_dim), c.shape[1]], dtype=np.complex128) # lobpcg
+    current_phi[basis.grid_idx_k[kid]] = c
+    current_phi = current_phi.reshape(basis.real_space_grid_dim)
+    current_phi = np.fft.fftn(current_phi) 
 
     # exchange
+    Kij_G = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
     Ki_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
     if xc == 'hf' and not ace_exchange:
-        for j in range(0, ne):
+        for j in range(0, nmo): # note, this has changed from ne to nmo with the introduction of occupation_numbers
 
             # Cij(r') = phi_i(r') phi_j*(r')
             # Cij(g) = FFT[Cij(r')]
-            tmp = np.fft.ifftn(occ_list[j].conj() * occ)
+            tmp = np.fft.ifftn(phi_r[j].conj() * current_phi)
             Cij = tmp.ravel()[basis.flat_idx]
 
             # Kij(g) = Cij(g) * FFT[1/|r-r'|]
@@ -580,12 +584,12 @@ def fock_on_orbitals_using_ace(basis, kid, ne, nmo, occ, c, T, v_r, Vnl, xc, Ki,
 
             # action of K on an occupied orbital, i: 
             # Ki(r) = sum_j Kij(r) phi_j(r)
-            Ki_r += Kij_r * occ_list[j]
+            Ki_r += Kij_r * phi_r[j] * occupation_numbers[j]
 
         Ki_r *= -4.0 * np.pi / basis.omega
 
     # action of potential on orbitals in real space, then transform to reciprocal space
-    tmp = v_r * occ  # real space, 3d
+    tmp = v_r * current_phi  # real space, 3d
     tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
     tmp = tmp.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
     tmp = tmp[basis.kg_to_g[kid]] # reciprocal space, small flattened basis
@@ -866,6 +870,12 @@ def uks(cell, basis,
     #if nbeta > nalpha:  
     #    nmo = nbeta
 
+    # occupation numbers
+    occ_num_alpha = np.ones(nmo_alpha, dtype=np.float64)
+    occ_num_beta = np.ones(nmo_beta, dtype=np.float64)
+    occ_num_alpha[nalpha:] = 0.0
+    occ_num_beta[nbeta:] = 0.0
+
     for kid in range ( len(basis.kpts) ):
 
         Calpha.append(np.random.rand(basis.n_plane_waves_per_k[kid], nmo_alpha) * 1e-8)
@@ -889,9 +899,9 @@ def uks(cell, basis,
         epsilon_alpha.append(np.zeros((nmo_alpha), dtype='complex128'))
         epsilon_beta.append(np.zeros((nmo_beta), dtype='complex128'))
 
-    # initialize occ_alpha and occ_beta arrays ... won't work for kpts > 0
-    rho_alpha, occ_alpha = get_density(basis, Calpha[0], nalpha, nmo_alpha, kid)
-    rho_beta, occ_beta = get_density(basis, Cbeta[0], nbeta, nmo_beta, kid)
+    # initialize phi_alpha and phi_beta arrays ... won't work for kpts > 0
+    rho_alpha, phi_alpha = get_density(basis, Calpha[0], nalpha, nmo_alpha, kid, occ_num_alpha)
+    rho_beta, phi_beta = get_density(basis, Cbeta[0], nbeta, nmo_beta, kid, occ_num_beta)
 
     # kinetic energy
     T = []
@@ -946,8 +956,8 @@ def uks(cell, basis,
             if jellium:
                 Vnl *= 0.0
 
-            Fa_c, Ki_alpha[kid], exchange_alpha = fock_on_orbitals(basis, kid, nalpha, nmo_alpha, occ_alpha, Calpha, T, v_alpha_r, Vnl, xc)
-            Fb_c, Ki_beta[kid], exchange_beta = fock_on_orbitals(basis, kid, nbeta, nmo_beta, occ_beta, Cbeta, T, v_beta_r, Vnl, xc)
+            Fa_c, Ki_alpha[kid], exchange_alpha = fock_on_orbitals(basis, kid, nalpha, nmo_alpha, phi_alpha, Calpha, T, v_alpha_r, Vnl, xc, occ_num_alpha)
+            Fb_c, Ki_beta[kid], exchange_beta = fock_on_orbitals(basis, kid, nbeta, nmo_beta, phi_beta, Cbeta, T, v_beta_r, Vnl, xc, occ_num_beta)
 
             if xc == 'hf':
 
@@ -999,7 +1009,6 @@ def uks(cell, basis,
         rho_beta = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
 
         # diagonalize fock matrix with extrapolated potential
-        Kij_G = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
 
         for kid in range ( len(basis.kpts) ):
 
@@ -1013,18 +1022,18 @@ def uks(cell, basis,
                 Vnl *= 0.0
 
             def lobpcg_alpha(c):
-                return fock_on_orbitals_using_ace(basis, kid, nalpha, nmo_alpha, occ_alpha, c, T, v_alpha_r, Vnl, xc, Ki_alpha[kid], B_alpha_ace[kid], ace_exchange)
+                return fock_on_orbitals_using_ace(basis, kid, nalpha, nmo_alpha, phi_alpha, c, T, v_alpha_r, Vnl, xc, Ki_alpha[kid], B_alpha_ace[kid], ace_exchange, occ_num_alpha)
 
             def lobpcg_beta(c):
-                return fock_on_orbitals_using_ace(basis, kid, nbeta, nmo_beta, occ_beta, c, T, v_beta_r, Vnl, xc, Ki_beta[kid], B_beta_ace[kid], ace_exchange)
+                return fock_on_orbitals_using_ace(basis, kid, nbeta, nmo_beta, phi_beta, c, T, v_beta_r, Vnl, xc, Ki_beta[kid], B_beta_ace[kid], ace_exchange, occ_num_beta)
 
             if not jellium:
 
                 Fa_C = LinearOperator((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), matvec=lobpcg_alpha, dtype='complex128')
                 Fb_C = LinearOperator((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), matvec=lobpcg_beta, dtype='complex128')
 
-                epsilon_alpha[kid], Calpha[kid] = scipy.sparse.linalg.lobpcg(Fa_C, Calpha[kid], largest=False, maxiter=2000, tol=d_convergence*0.1)
-                epsilon_beta[kid], Cbeta[kid] = scipy.sparse.linalg.lobpcg(Fb_C, Cbeta[kid], largest=False, maxiter=2000, tol=d_convergence*0.1)
+                epsilon_alpha[kid], Calpha[kid] = scipy.sparse.linalg.lobpcg(Fa_C, Calpha[kid], largest=False, maxiter=200, tol=d_convergence*0.01)
+                epsilon_beta[kid], Cbeta[kid] = scipy.sparse.linalg.lobpcg(Fb_C, Cbeta[kid], largest=False, maxiter=200, tol=d_convergence*0.01)
 
             else :
                 #epsilon_alpha[kid], Calpha[kid] = scipy.linalg.eigh(np.diag(T[kid]), eigvals=(0, nalpha))
@@ -1059,8 +1068,8 @@ def uks(cell, basis,
                 Cbeta[kid] = Calpha[kid].copy()
 
             # update density
-            my_rho_alpha, occ_alpha = get_density(basis, Calpha[kid], nalpha, nmo_alpha, kid)
-            my_rho_beta, occ_beta = get_density(basis, Cbeta[kid], nbeta, nmo_beta, kid)
+            my_rho_alpha, phi_alpha = get_density(basis, Calpha[kid], nalpha, nmo_alpha, kid, occ_num_alpha)
+            my_rho_beta, phi_beta = get_density(basis, Cbeta[kid], nbeta, nmo_beta, kid, occ_num_beta)
 
             # density should be non-negative ...
             rho_alpha += my_rho_alpha.clip(min = 0)
@@ -1099,9 +1108,9 @@ def uks(cell, basis,
         else :
 
             # exact exchange energy
-            xc_energy = get_exact_exchange_energy(basis, occ_alpha, nalpha, Calpha)
+            xc_energy = get_exact_exchange_energy(basis, phi_alpha, nalpha, Calpha, occ_num_alpha)
             if nbeta > 0:
-                my_xc_energy = get_exact_exchange_energy(basis, occ_beta, nbeta, Cbeta)
+                my_xc_energy = get_exact_exchange_energy(basis, phi_beta, nbeta, Cbeta, occ_num_beta)
                 xc_energy += my_xc_energy
 
             # jellium

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -856,24 +856,23 @@ def uks(cell, basis,
     Ki_beta = []
 
     # nmo ... number of desired molecular orbitals ... must be at least ne
-    # TODO: ace doesn't always work correctly for nmo > ne
-    nmo = nalpha
-    if nbeta > nalpha: 
-        nmo = nbeta
+    # warning: ace has trouble for nmo > ne with eigsh, but lobpcg seems to work
+    nmo = nalpha + 1
+    if nbeta > nalpha:  
+        nmo = nbeta  + 1
 
     for kid in range ( len(basis.kpts) ):
 
-        Calpha.append(np.random.rand(basis.n_plane_waves_per_k[kid], nmo) * 1e-8)
-        Cbeta.append(np.random.rand(basis.n_plane_waves_per_k[kid], nmo) * 1e-8)
-        #for i in range (nmo):
-        #    Calpha[kid][i, i] = 1.0
-        #for i in range (nmo):
-        #    Cbeta[kid][i, i] = 1.0
-        #Calpha[kid] = orthonormalize(Calpha[kid])
-        #Cbeta[kid] = orthonormalize(Cbeta[kid])
-
-        #Calpha.append(np.zeros((basis.n_plane_waves_per_k[kid], nalpha+1), dtype='complex128'))
-        #Cbeta.append(np.zeros((basis.n_plane_waves_per_k[kid], nbeta+1), dtype='complex128'))
+        #Calpha.append(np.random.rand(basis.n_plane_waves_per_k[kid], nmo) * 1e-8)
+        #Cbeta.append(np.random.rand(basis.n_plane_waves_per_k[kid], nmo) * 1e-8)
+        Calpha.append(np.zeros((basis.n_plane_waves_per_k[kid], nmo), dtype='complex128'))
+        Cbeta.append(np.zeros((basis.n_plane_waves_per_k[kid], nmo), dtype='complex128'))
+        for i in range (nmo):
+            Calpha[kid][i, i] = 1.0
+        for i in range (nmo):
+            Cbeta[kid][i, i] = 1.0
+        Calpha[kid] = orthonormalize(Calpha[kid])
+        Cbeta[kid] = orthonormalize(Cbeta[kid])
 
 
         Binv_alpha_ace.append(np.zeros((nmo, nmo), dtype='complex128'))
@@ -1073,6 +1072,7 @@ def uks(cell, basis,
             # for ace < phi_i | Kj>^{-1}
             tmp = -Calpha[kid][:, :nmo].conj().T @ Ki_alpha[kid]
             L = np.linalg.cholesky(tmp)
+
             # how's our cholesky decomposition looking?
             assert (np.allclose(tmp, L @ L.conj().T))
 
@@ -1083,8 +1083,8 @@ def uks(cell, basis,
             assert (np.allclose(-tmp @ Binv_alpha_ace[kid], np.eye(tmp.shape[0])))
 
             tmp = -Cbeta[kid][:, :nmo].conj().T @ Ki_beta[kid]
-            tmp = 0.5 * (tmp + tmp.conj().T)
             L = np.linalg.cholesky(tmp)
+
             # how's our cholesky decomposition looking?
             assert (np.allclose(tmp, L @ L.conj().T))
 
@@ -1188,7 +1188,8 @@ def uks(cell, basis,
                 """
 
                 # orbital in real space
-                occ = np.zeros(np.prod(grid_shape), dtype=np.complex128)
+                #occ = np.zeros(np.prod(grid_shape), dtype=np.complex128) # eigsh
+                occ = np.zeros([np.prod(grid_shape), c.shape[1]], dtype=np.complex128) # lobpcg
                 occ[grid_idx_k[kid]] = c
                 occ = occ.reshape(grid_shape)
                 occ = np.fft.fftn(occ) 
@@ -1219,10 +1220,19 @@ def uks(cell, basis,
                 tmp = my_v_r * occ  # real space, 3d
                 tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
                 tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
+                tmp = tmp[basis.kg_to_g[kid]] # reciprocal space, small flattened basis
+                tmp = tmp.reshape(c.shape) # for lobpcg
 
-                F_c = T[kid] * c + tmp[basis.kg_to_g[kid]] + Vnl @ c
+                #F_c = T[kid] * c + tmp + Vnl @ c # eigsh
+                F_c = T[kid][:, None] * c + tmp + Vnl @ c # lobpcg
 
-                # for ace
+                #print('v_r * occ', tmp.shape)
+                #print('Vnl * c  ', (Vnl @ c).shape)
+                #print('T * c    ', (T[kid][:, None] * c).shape)
+                #print('c        ', c.shape)
+                #print('F c      ', F_c.shape)
+
+                # ace
 
                 # (< phi_j | K) | c >
                 tmp = my_Ki.conj().T @ c
@@ -1235,22 +1245,19 @@ def uks(cell, basis,
                     F_c += ace
 
                 # exact exchange
-                tmp = Ki_r # real space, 3d
-                tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
-                tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
-                tmp = tmp[basis.kg_to_g[kid]] # reciprocal space, small flattened basis
-
                 if not ace_exchange :
+                    tmp = Ki_r # real space, 3d
+                    tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
+                    tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
+                    tmp = tmp[basis.kg_to_g[kid]] # reciprocal space, small flattened basis
+                    tmp = tmp.reshape(c.shape) # for lobpcg
+
                     F_c += tmp
-                
+
                 #print(np.linalg.norm(ace - tmp))
 
-                #assert np.allclose(F_c, fock_a[kid] @ c)
-                #print(np.linalg.norm(F_c - fock_a[kid] @ c))
-
                 return F_c
-                #return fock_a[kid] @ c
-            
+
             F_C = LinearOperator((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), matvec=apply_fock_operator_to_orbital, dtype='complex128')
 
             my_N = nalpha
@@ -1258,16 +1265,14 @@ def uks(cell, basis,
             my_v_r = v_alpha_r.copy()
             my_Ki = Ki_alpha[kid].copy()
             my_Binv = Binv_alpha_ace[kid].copy()
-            epsilon_alpha[kid], Calpha[kid] = scipy.sparse.linalg.eigsh(F_C, k=nmo, which="SA", v0 = Calpha[kid][:,0])
-            #epsilon_alpha[kid], Calpha[kid] = scipy.sparse.linalg.lobpcg(F_C, Calpha[kid], largest=False)
+            epsilon_alpha[kid], Calpha[kid] = scipy.sparse.linalg.lobpcg(F_C, Calpha[kid], largest=False, maxiter=200, tol=d_convergence*0.1)
 
             my_N = nbeta
             occ_list = occ_beta.copy()
             my_v_r = v_beta_r.copy()
             my_Ki = Ki_beta[kid].copy()
             my_Binv = Binv_beta_ace[kid].copy()
-            epsilon_beta[kid], Cbeta[kid] = scipy.sparse.linalg.eigsh(F_C, k=nmo, which="SA", v0 = Cbeta[kid][:,0])
-            #epsilon_beta[kid], Cbeta[kid] = scipy.sparse.linalg.lobpcg(F_C, Cbeta[kid], largest=False)
+            epsilon_beta[kid], Cbeta[kid] = scipy.sparse.linalg.lobpcg(F_C, Cbeta[kid], largest=False, maxiter=200, tol=d_convergence*0.1)
 
             #epsilon_alpha[kid], Calpha[kid] = scipy.linalg.eigh(fock_a[kid], eigvals=(0, nalpha))
             #epsilon_beta[kid], Cbeta[kid] = scipy.linalg.eigh(fock_b[kid], eigvals=(0, nbeta))

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -794,7 +794,7 @@ def uks(cell, basis,
     # damp fock matrix (helps with convergence sometimes)
     damping_factor = 1.0
     if damp_fock :
-        damping_factor = 0.50
+        damping_factor = 0.8
 
     # diis 
     diis_dimension = 8

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -722,7 +722,8 @@ def uks(cell, basis,
         d_convergence = 1e-6, 
         diis_dimension = 8, 
         damp_fock = True, 
-        damping_iterations = 8,
+        damping_iterations = 4,
+        ace_exchange = True,
         maxiter=500):
 
     """
@@ -810,8 +811,8 @@ def uks(cell, basis,
         damping_factor = 0.2
 
     # diis 
-    diis_dimension = 6
-    diis_start_cycle = 4
+    diis_dimension = 8
+    diis_start_cycle = damping_iterations
 
     print("")
     print('    exchange functional:                         %20s' % ( functional_name_dict[xc][0] ) )
@@ -839,14 +840,8 @@ def uks(cell, basis,
 
     old_total_energy = 0.0
 
-    fock_a = []
-    fock_b = []
-
     Calpha = []
     Cbeta = []
-
-    old_fock_a = []
-    old_fock_b = []
 
     epsilon_alpha = []
     epsilon_beta = []
@@ -859,15 +854,6 @@ def uks(cell, basis,
     Ki_beta = []
 
     for kid in range ( len(basis.kpts) ):
-
-        fock_a.append(np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128'))
-        fock_b.append(np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128'))
-
-        old_fock_a.append(np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128'))
-        old_fock_b.append(np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128'))
-
-        #Calpha.append(np.eye(basis.n_plane_waves_per_k[kid]))
-        #Cbeta.append(np.eye(basis.n_plane_waves_per_k[kid]))
 
         #Calpha.append(np.random.rand(basis.n_plane_waves_per_k[kid], nalpha + 1) * 1e-8)
         #Cbeta.append(np.random.rand(basis.n_plane_waves_per_k[kid], nbeta + 1) * 1e-8)
@@ -932,12 +918,6 @@ def uks(cell, basis,
         kgtmp = basis.kpts[kid] + basis.g[basis.kg_to_g[kid, :basis.n_plane_waves_per_k[kid]]]
         T.append(np.einsum('ij,ij->i', kgtmp, kgtmp) / 2.0)
 
-    #fock_a = []
-    #fock_b = []
-    #for kid in range ( len(basis.kpts) ):
-    #    fock_a.append(np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128'))
-    #    fock_b.append(np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128'))
-
     v_alpha = 0 * v_ne
     v_beta = 0 * v_ne
     v_alpha_old = 0 * v_ne
@@ -990,6 +970,7 @@ def uks(cell, basis,
             #Vnl *= 0.0
 
             Fa_c = np.zeros((basis.n_plane_waves_per_k[kid], nalpha), dtype='complex128')
+            exchange_alpha = np.zeros((basis.n_plane_waves_per_k[kid], nalpha), dtype='complex128')
             for i in range (nalpha):
 
                 # exchange
@@ -1015,7 +996,7 @@ def uks(cell, basis,
                     Ki_r *= -4.0 * np.pi / basis.omega
 
                 # action of potential on orbitals in real space, then transform to reciprocal space
-                tmp = v_alpha_r * occ_alpha[i] + Ki_r # real space, 3d
+                tmp = v_alpha_r * occ_alpha[i] #+ Ki_r # real space, 3d
                 tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
                 tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
 
@@ -1027,7 +1008,14 @@ def uks(cell, basis,
                 tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
                 Ki_alpha[kid][:,i] = tmp[basis.kg_to_g[kid]] # reciprocal space, small flattened basis
 
+                # non-ace exchange
+                tmp = Ki_r # real space, 3d
+                tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
+                tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
+                exchange_alpha[:,i] = tmp[basis.kg_to_g[kid]] # map last term to small flattened basis
+
             Fb_c = np.zeros((basis.n_plane_waves_per_k[kid], nbeta), dtype='complex128')
+            exchange_beta = np.zeros((basis.n_plane_waves_per_k[kid], nalpha), dtype='complex128')
             for i in range (nbeta):
 
                 # exchange
@@ -1053,10 +1041,9 @@ def uks(cell, basis,
                     Ki_r *= -4.0 * np.pi / basis.omega 
 
                 # action of potential on orbitals in real space, then transform to reciprocal space
-                tmp = v_beta_r * occ_beta[i] + Ki_r  # real space, 3d
+                tmp = v_beta_r * occ_beta[i] #+ Ki_r  # real space, 3d
                 tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
                 tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
-
                 Fb_c[:,i] = T[kid] * Cbeta[kid][:, i] + tmp[basis.kg_to_g[kid]] # map last term to small flattened basis
 
                 # for ace
@@ -1064,6 +1051,12 @@ def uks(cell, basis,
                 tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
                 tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
                 Ki_beta[kid][:,i] = tmp[basis.kg_to_g[kid]] # reciprocal space, small flattened basis
+
+                # non-ace exchange
+                tmp = Ki_r # real space, 3d
+                tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
+                tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
+                exchange_beta[:,i] = tmp[basis.kg_to_g[kid]] # map last term to small flattened basis
 
             # for ace < phi_i | Kj>^{-1}
             if scf_iter > 0 :
@@ -1073,6 +1066,7 @@ def uks(cell, basis,
                 Linv = np.linalg.inv(L)
                 Binv_alpha_ace[kid] = -Linv.conj().T @ Linv
 
+                # how's our inverse looking?
                 assert (np.allclose(-tmp @ Binv_alpha_ace[kid], np.eye(tmp.shape[0])))
 
                 tmp = -Cbeta[kid][:, :nbeta].conj().T @ Ki_beta[kid]
@@ -1080,6 +1074,7 @@ def uks(cell, basis,
                 Linv = np.linalg.inv(L)
                 Binv_beta_ace[kid] = -Linv.conj().T @ Linv
 
+                # how's our inverse looking?
                 assert (np.allclose(-tmp @ Binv_beta_ace[kid], np.eye(tmp.shape[0])))
 
             else:
@@ -1101,8 +1096,12 @@ def uks(cell, basis,
             # sum_i K | phi_i >  Binv_{ij} < phi_j | K | c >
             ace_beta = Ki_beta[kid] @ tmp 
 
-            #Fa_c += ace_alpha
-            #Fb_c += ace_beta
+            # is ace representation equivalent to original exact exchange representation?
+            assert (np.allclose(ace_alpha, exchange_alpha))
+            assert (np.allclose(ace_beta, exchange_beta))
+
+            Fa_c += ace_alpha
+            Fb_c += ace_beta
             
             Fa_c += Vnl @ Calpha[kid][:, :nalpha]
             Fb_c += Vnl @ Cbeta[kid][:, :nbeta]
@@ -1115,20 +1114,7 @@ def uks(cell, basis,
             grad_a = Fa_c - Calpha[kid][:,:nalpha] @ c_Fa_c
             grad_b = Fb_c - Cbeta[kid][:,:nbeta] @ c_Fb_c
 
-            #print('new way', np.linalg.norm(grad_a), np.linalg.norm(grad_b))
-
-            # orbital gradient from [D, F] with the full fock and density matrices
-            #fock_a[kid] = form_fock_matrix(basis, kid, v = v_alpha + v_ne) + Vnl + exchange_matrix_alpha
-            #fock_b[kid] = form_fock_matrix(basis, kid, v = v_beta + v_ne) + Vnl + exchange_matrix_beta
-            #Fa_c = fock_a[kid] @ Calpha[kid][:, :nalpha]
-            #Fb_c = fock_b[kid] @ Cbeta[kid][:, :nbeta]
-            #grad_a = form_orbital_gradient(basis, Calpha[kid], nalpha, fock_a[kid], kid)
-            #grad_b = form_orbital_gradient(basis, Cbeta[kid], nbeta, fock_b[kid], kid)
-            #print('old way', np.linalg.norm(grad_a), np.linalg.norm(grad_b))
-
             error_vector = np.hstack( (error_vector, grad_a.flatten(), grad_b.flatten() ) )
-
-        # extrapolate coulomb potential
 
         # norm of orbital gradient
         conv = np.linalg.norm(error_vector)
@@ -1148,57 +1134,6 @@ def uks(cell, basis,
             new_solution_vector = inner_diis.update(solution_vector, error_vector)
             v_alpha = new_solution_vector[:len(v_alpha)]
             v_beta = new_solution_vector[len(v_alpha):]
-
-        #rho_alpha_old = rho_alpha.copy()
-        #rho_beta_old = rho_beta.copy()
-
-        ## damp or extrapolate density
-        #if scf_iter < diis_start_cycle:
-
-        #    # damping?
-        #    rho_alpha = (1.0-damp) * rho_alpha + damp * rho_alpha_old
-        #    rho_beta = (1.0-damp) * rho_beta + damp * rho_beta_old
-
-        #else :
-
-        #    #v_coulomb = inner_diis.update(v_coulomb, error_vector)
-
-        #    solution_vector = np.hstack( (rho_alpha.flatten(), rho_beta.flatten()) )
-        #    new_solution_vector = inner_diis.update(solution_vector, error_vector)
-        #    rho_alpha = new_solution_vector[:len(solution_vector)//2].reshape(rho_alpha_old.shape).real
-        #    rho_beta = new_solution_vector[len(solution_vector)//2:].reshape(rho_beta_old.shape).real
-
-        #rho_alpha = rho_alpha.clip(min = 0)
-        #rho_beta = rho_beta.clip(min = 0)
-
-        ## need to rebuild potential
-        #rho = rho_alpha + rho_beta
-
-        ## coulomb potential
-        #tmp = np.fft.ifftn(rho)
-        #for myg in range( len(basis.g) ):
-        #    inner_rhog[myg] = tmp[ get_miller_indices(myg, basis) ]
-
-        #v_coulomb = 4.0 * np.pi * np.divide(inner_rhog, basis.g2, out = np.zeros_like(basis.g2), where = basis.g2 != 0.0)
-
-        ## exchange-correlation potential
-        #if xc != 'hf' :
-
-        #    v_xc_alpha, v_xc_beta = get_xc_potential(xc, basis, rho_alpha, rho_beta, libxc_x_functional, libxc_c_functional)
-        #    xc_energy = get_xc_energy(xc, basis, rho_alpha, rho_beta, libxc_x_functional, libxc_c_functional)
-
-        #else :
-
-        #    # we'll deal with hf exchange matrices on the fly ... here, just get the energy
-        #    xc_energy, exchange_matrix_alpha = get_exact_exchange_energy(basis, occ_alpha, nalpha, Calpha, exchange_matrix_alpha, False)
-        #    if nbeta > 0:
-        #        my_xc_energy, exchange_matrix_beta = get_exact_exchange_energy(basis, occ_beta, nbeta, Cbeta, exchange_matrix_beta, False)
-        #        xc_energy += my_xc_energy
-        #    xc_energy -= 0.5 * (nalpha + nbeta) * madelung
-
-
-        #fock_a[kid] = form_fock_matrix(basis, kid, v = v_alpha + v_ne) + Vnl + exchange_matrix_alpha
-        #fock_b[kid] = form_fock_matrix(basis, kid, v = v_beta + v_ne) + Vnl + exchange_matrix_beta
 
         # potential in real space
         v_alpha_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
@@ -1246,7 +1181,7 @@ def uks(cell, basis,
 
                 # exchange
                 Ki_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
-                if xc == 'hf' :
+                if xc == 'hf' and not ace_exchange:
                     for j in range(0, my_N):
 
                         # Cij(r') = phi_i(r') phi_j*(r')
@@ -1282,7 +1217,8 @@ def uks(cell, basis,
                 # sum_i K | phi_i >  Binv_{ij} < phi_j | K | c >
                 ace = my_Ki @ tmp 
 
-                #F_c += ace
+                if ace_exchange :
+                    F_c += ace
 
                 # exact exchange
                 tmp = Ki_r # real space, 3d
@@ -1290,7 +1226,8 @@ def uks(cell, basis,
                 tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
                 tmp = tmp[basis.kg_to_g[kid]] # reciprocal space, small flattened basis
 
-                F_c += tmp
+                if not ace_exchange :
+                    F_c += tmp
                 
                 #print(np.linalg.norm(ace - tmp))
 
@@ -1299,11 +1236,8 @@ def uks(cell, basis,
 
                 return F_c
                 #return fock_a[kid] @ c
-
+            
             F_C = LinearOperator((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), matvec=apply_fock_operator_to_orbital, dtype='complex128')
-
-            #epsilon_alpha, Calpha[kid] = lobpcg(F_Calpha, Calpha[kid], largest=False, tol=0.1*d_convergence, maxiter=200)
-            #epsilon_beta, Cbeta[kid] = lobpcg(F_Cbeta, Cbeta[kid], largest=False, tol=0.1*d_convergence, maxiter=200)
 
             my_N = nalpha
             occ_list = occ_alpha.copy()
@@ -1325,9 +1259,6 @@ def uks(cell, basis,
             # why do i need to orthonormalize my orbitals???
             Calpha[kid] = orthonormalize(Calpha[kid])
             Cbeta[kid] = orthonormalize(Cbeta[kid])
-
-            #epsilon_alpha, Calpha = np.linalg.eigh(fock_a)
-            #epsilon_beta, Cbeta = np.linalg.eigh(fock_b)
 
             # break spin symmetry? # TODO this is broken, which probably indicates there is some other problem ...
             #if guess_mix is True and scf_iter == 0:
@@ -1410,41 +1341,6 @@ def uks(cell, basis,
         if conv < d_convergence and energy_diff < e_convergence :
             break
 
-        #inner_diis = lib.diis.DIIS()
-        #inner_diis.space = diis_dimension
-
-        #if xc != 'hf':
-
-        #    if conv < d_convergence and energy_diff < e_convergence :
-        #        break
-
-        #else :
-
-        #    if (conv < d_convergence and energy_diff < e_convergence and recompute_exchange) :
-        #        break
-
-        #    elif (conv < d_convergence and energy_diff < e_convergence and not recompute_exchange or scf_iter == 0):
-
-        #        # update exchange matrix for next set of inner iterations
-
-        #        # TODO: fix for general k
-        #        print('')
-        #        print('        ==> recomputing exchange matrix <==')
-        #        print('')
-        #        recompute_exchange = True
-        #        xc_energy, exchange_matrix_alpha = get_exact_exchange_energy(basis, occ_alpha, nalpha, Calpha, exchange_matrix_alpha, recompute_exchange)
-        #        if nbeta > 0:
-        #            my_xc_energy, exchange_matrix_beta = get_exact_exchange_energy(basis, occ_beta, nbeta, Cbeta, exchange_matrix_beta, recompute_exchange)
-        #            xc_energy += my_xc_energy
-        #        xc_energy -= 0.5 * (nalpha + nbeta) * madelung
-
-        #        # reset diis ... not sure why this is necessary, but convergence is slow otherwise
-        #        #inner_diis = lib.diis.DIIS()
-        #        #inner_diis.space = diis_dimension
-
-        #    else :
-        #        recompute_exchange = False
-
     if scf_iter == maxiter - 1:
         print('')
         print('    UKS iterations did not converge.')
@@ -1464,8 +1360,6 @@ def uks(cell, basis,
     print('')
     print('    total energy:             %20.12lf' % ( np.real(one_electron_energy) + np.real(coulomb_energy) + np.real(xc_energy) + enuc ) )
     print('')
-
-    #assert(np.isclose( np.real(one_electron_energy) + np.real(coulomb_energy) + np.real(xc_energy) + enuc, -9.802901383306) )
 
     return np.real(one_electron_energy) + np.real(coulomb_energy) + np.real(xc_energy) + enuc, Calpha, Cbeta
 

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -705,7 +705,7 @@ def get_coulomb_energy(basis, C, N, kid, v_coulomb):
 
 def uks(cell, basis, 
         xc = 'lda', 
-        guess_mix = True, 
+        guess_mix = False, 
         e_convergence = 1e-8, 
         d_convergence = 1e-6, 
         diis_dimension = 8, 
@@ -821,6 +821,13 @@ def uks(cell, basis,
     print('    no. damping iterations:                      %20i' % ( damping_iterations ) )
     #print('    diis start iteration:                        %20i' % ( diis_start_cycle ) )
     print('    no. diis vectors:                            %20i' % ( diis_dimension ) )
+
+    if guess_mix :
+        print("")
+        print("    ==> WARNING <==")
+        print("")
+        print("        guess_mix = True is not working and is currently disabled")
+ 
 
     print("")
     print("    ==> Begin UKS Iterations <==")

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -671,6 +671,117 @@ def get_coulomb_energy(basis, C, N, kid, v_coulomb):
 
     return coulomb_energy
 
+def fock_on_orbitals(basis, kid, ne, nmo, occ, C, T, v_r, Vnl, xc):
+    """
+    evaluate action of fock matrix on orbitals
+
+    :param basis: the plane wave basis object
+    :param kid: the current k-point
+    :param ne: number of electrons
+    :param nmo: number of bands (could be larger than ne)
+    :param occ: occupied orbitals, in real space
+    :param C: occupied orbitals, in reciprocal space
+    :param T: diagonal of the kinetic energy matrix, in reciprocal space
+    :param v_r: the potential (coulomb + local pseudopotential + xc), in real space
+    :param Vnl: matrix representation of non-local pseudopotential, in reciprocal space
+    :param xc: the exchange-correlation functional
+
+
+    :return F_c: the action of the fock matrix on the orbials
+    :return Ki: exchange operator acting on orbitals, i, in reciprocal space
+    :return exchange: the exchange matrix
+    """
+
+
+    Kij_G = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
+    Ki = np.zeros((basis.n_plane_waves_per_k[kid], nmo), dtype='complex128')
+    F_c = np.zeros((basis.n_plane_waves_per_k[kid], nmo), dtype='complex128')
+    exchange = np.zeros((basis.n_plane_waves_per_k[kid], nmo), dtype='complex128')
+    for i in range (nmo):
+
+        # exchange
+        Ki_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
+        if xc == 'hf':
+            for j in range(0, ne):
+
+                # Cij(r') = phi_i(r') phi_j*(r')
+                # Cij(g) = FFT[Cij(r')]
+                tmp = np.fft.ifftn(occ[j].conj() * occ[i])
+                Cij = tmp.ravel()[basis.flat_idx]
+
+                # Kij(g) = Cij(g) * FFT[1/|r-r'|]
+                Kij_G.ravel()[basis.flat_idx] = Cij * basis.inv_g2 #Kij
+
+                # Kij(r) = FFT^-1[Kij(g)]
+                Kij_r = np.fft.fftn(Kij_G)
+
+                # action of K on an occupied orbital, i: 
+                # Ki(r) = sum_j Kij(r) phi_j(r)
+                Ki_r += Kij_r * occ[j]
+
+            Ki_r *= -4.0 * np.pi / basis.omega
+
+        # action of potential on orbitals in real space, then transform to reciprocal space
+        tmp = v_r * occ[i] #+ Ki_r # real space, 3d
+        tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
+        tmp = tmp.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
+
+        F_c[:,i] = T[kid] * C[kid][:, i] + tmp[basis.kg_to_g[kid]] # map last term to small flattened basis
+
+        # for ace
+        tmp = Ki_r # real space, 3d
+        tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
+        tmp = tmp.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
+        Ki[:,i] = tmp[basis.kg_to_g[kid]] # reciprocal space, small flattened basis
+
+        # non-ace exchange
+        tmp = Ki_r # real space, 3d
+        tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
+        tmp = tmp.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
+        exchange[:,i] = tmp[basis.kg_to_g[kid]] # map last term to small flattened basis
+
+    return F_c, Ki, exchange
+
+def build_B_ace(ne, nmo, C, Ki, exchange):
+    """
+    build B matrix for ACE
+    see text after Eq. 13 of J. Chem. Theory Comput. 12, 2242-2249 (2016).
+
+    :param ne: number of electrons
+    :param nmo: number of bands (could be greater than ne)
+    :param C: orbital coefficients in reciprocal space
+    :param Ki: action of exchange operator on orbitals in reciprocal space
+    :param exchange: exchange contribution to fock matrix (exact, for testing ace)
+
+    :return B_ace: the B matrix for ACE
+    """
+
+    # for ace < phi_i | Kj>^{-1}
+    tmp = -C[:, :nmo].conj().T @ Ki
+    L = np.linalg.cholesky(tmp)
+
+    # how's our cholesky decomposition looking?
+    assert (np.allclose(tmp, L @ L.conj().T))
+
+    Linv = np.linalg.inv(L)
+    B_ace = -Linv.conj().T @ Linv
+
+    # how's our inverse looking?
+    assert (np.allclose(-tmp @ B_ace, np.eye(tmp.shape[0])))
+
+    # test ACE representation of exchange
+
+    # (< phi_j | K) | c >
+    tmp = Ki.conj().T @ C[:, :nmo]
+    # sum_j B_{ij} < phi_j | K | c > 
+    tmp = B_ace @ tmp 
+    # sum_i K | phi_i >  B_{ij} < phi_j | K | c >
+    ace = Ki @ tmp 
+
+    assert (np.allclose(ace, exchange))
+
+    return B_ace
+
 def uks(cell, basis, 
         xc = 'lda', 
         guess_mix = False, 
@@ -815,8 +926,8 @@ def uks(cell, basis,
     epsilon_beta = []
 
     # for ace
-    Binv_alpha_ace = []
-    Binv_beta_ace = []
+    B_alpha_ace = []
+    B_beta_ace = []
 
     Ki_alpha = []
     Ki_beta = []
@@ -843,8 +954,8 @@ def uks(cell, basis,
         Cbeta[kid] = Calpha[kid].copy()
 
 
-        Binv_alpha_ace.append(np.zeros((nmo_alpha, nmo_alpha), dtype='complex128'))
-        Binv_beta_ace.append(np.zeros((nmo_beta, nmo_beta), dtype='complex128'))
+        B_alpha_ace.append(np.zeros((nmo_alpha, nmo_alpha), dtype='complex128'))
+        B_beta_ace.append(np.zeros((nmo_beta, nmo_beta), dtype='complex128'))
 
         Ki_alpha.append(np.zeros((basis.n_plane_waves_per_k[kid], nmo_alpha), dtype='complex128'))
         Ki_beta.append(np.zeros((basis.n_plane_waves_per_k[kid], nmo_beta), dtype='complex128'))
@@ -949,8 +1060,6 @@ def uks(cell, basis,
         # orbital gradient
         error_vector = np.zeros(0)
 
-        Kij_G = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
-
         for kid in range( len(basis.kpts) ):
 
             # TODO: don't store non-local pseudopotential in the planewave basis
@@ -963,144 +1072,16 @@ def uks(cell, basis,
             if jellium:
                 Vnl *= 0.0
 
-            Fa_c = np.zeros((basis.n_plane_waves_per_k[kid], nmo_alpha), dtype='complex128')
-            exchange_alpha = np.zeros((basis.n_plane_waves_per_k[kid], nmo_alpha), dtype='complex128')
-            for i in range (nmo_alpha):
-
-                # exchange
-                Ki_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
-                if xc == 'hf':
-                    for j in range(0, nalpha):
-
-                        # Cij(r') = phi_i(r') phi_j*(r')
-                        # Cij(g) = FFT[Cij(r')]
-                        tmp = np.fft.ifftn(occ_alpha[j].conj() * occ_alpha[i])
-                        Cij = tmp.ravel()[basis.flat_idx]
-
-                        # Kij(g) = Cij(g) * FFT[1/|r-r'|]
-                        Kij_G.ravel()[basis.flat_idx] = Cij * basis.inv_g2 #Kij
-
-                        # Kij(r) = FFT^-1[Kij(g)]
-                        Kij_r = np.fft.fftn(Kij_G)
-
-                        # action of K on an occupied orbital, i: 
-                        # Ki(r) = sum_j Kij(r) phi_j(r)
-                        Ki_r += Kij_r * occ_alpha[j]
-
-                    Ki_r *= -4.0 * np.pi / basis.omega
-
-                # action of potential on orbitals in real space, then transform to reciprocal space
-                tmp = v_alpha_r * occ_alpha[i] #+ Ki_r # real space, 3d
-                tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
-                tmp = tmp.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
-
-                Fa_c[:,i] = T[kid] * Calpha[kid][:, i] + tmp[basis.kg_to_g[kid]] # map last term to small flattened basis
-
-                # for ace
-                tmp = Ki_r # real space, 3d
-                tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
-                tmp = tmp.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
-                Ki_alpha[kid][:,i] = tmp[basis.kg_to_g[kid]] # reciprocal space, small flattened basis
-
-                # non-ace exchange
-                tmp = Ki_r # real space, 3d
-                tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
-                tmp = tmp.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
-                exchange_alpha[:,i] = tmp[basis.kg_to_g[kid]] # map last term to small flattened basis
-
-            Fb_c = np.zeros((basis.n_plane_waves_per_k[kid], nmo_beta), dtype='complex128')
-            exchange_beta = np.zeros((basis.n_plane_waves_per_k[kid], nmo_beta), dtype='complex128')
-            for i in range (nmo_beta):
-
-                # exchange
-                Ki_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
-                if xc == 'hf':
-                    for j in range(0, nbeta):
-
-                        # Cij(r') = phi_i(r') phi_j*(r')
-                        # Cij(g) = FFT[Cij(r')]
-                        tmp = np.fft.ifftn(occ_beta[j].conj() * occ_beta[i])
-                        Cij = tmp.ravel()[basis.flat_idx]
-
-                        # Kij(g) = Cij(g) * FFT[1/|r-r'|]
-                        Kij_G.ravel()[basis.flat_idx] = Cij * basis.inv_g2 #Kij
-
-                        # Kij(r) = FFT^-1[Kij(g)]
-                        Kij_r = np.fft.fftn(Kij_G)
-
-                        # action of K on an occupied orbital, i: 
-                        # Ki(r) = sum_j Kij(r) phi_j(r)
-                        Ki_r += Kij_r * occ_beta[j]
-
-                    Ki_r *= -4.0 * np.pi / basis.omega 
-
-                # action of potential on orbitals in real space, then transform to reciprocal space
-                tmp = v_beta_r * occ_beta[i] #+ Ki_r  # real space, 3d
-                tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
-                tmp = tmp.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
-                Fb_c[:,i] = T[kid] * Cbeta[kid][:, i] + tmp[basis.kg_to_g[kid]] # map last term to small flattened basis
-
-                # for ace
-                tmp = Ki_r  # real space, 3d
-                tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
-                tmp = tmp.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
-                Ki_beta[kid][:,i] = tmp[basis.kg_to_g[kid]] # reciprocal space, small flattened basis
-
-                # non-ace exchange
-                tmp = Ki_r # real space, 3d
-                tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
-                tmp = tmp.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
-                exchange_beta[:,i] = tmp[basis.kg_to_g[kid]] # map last term to small flattened basis
+            Fa_c, Ki_alpha[kid], exchange_alpha = fock_on_orbitals(basis, kid, nalpha, nmo_alpha, occ_alpha, Calpha, T, v_alpha_r, Vnl, xc)
+            Fb_c, Ki_beta[kid], exchange_beta = fock_on_orbitals(basis, kid, nbeta, nmo_beta, occ_beta, Cbeta, T, v_beta_r, Vnl, xc)
 
             if xc == 'hf':
 
-                # for ace < phi_i | Kj>^{-1}
-                tmp = -Calpha[kid][:, :nmo_alpha].conj().T @ Ki_alpha[kid]
-                L = np.linalg.cholesky(tmp)
+                B_alpha_ace[kid] = build_B_ace(nalpha, nmo_alpha, Calpha[kid], Ki_alpha[kid], exchange_alpha)
+                B_beta_ace[kid] = build_B_ace(nbeta, nmo_beta, Cbeta[kid], Ki_beta[kid], exchange_beta)
 
-                # how's our cholesky decomposition looking?
-                assert (np.allclose(tmp, L @ L.conj().T))
-
-                Linv = np.linalg.inv(L)
-                Binv_alpha_ace[kid] = -Linv.conj().T @ Linv
-
-                # how's our inverse looking?
-                assert (np.allclose(-tmp @ Binv_alpha_ace[kid], np.eye(tmp.shape[0])))
-
-                tmp = -Cbeta[kid][:, :nmo_beta].conj().T @ Ki_beta[kid]
-                L = np.linalg.cholesky(tmp)
-
-                # how's our cholesky decomposition looking?
-                assert (np.allclose(tmp, L @ L.conj().T))
-
-                Linv = np.linalg.inv(L)
-                Binv_beta_ace[kid] = -Linv.conj().T @ Linv
-
-                # how's our inverse looking?
-                assert (np.allclose(-tmp @ Binv_beta_ace[kid], np.eye(tmp.shape[0])))
-
-                # for ace
-
-                # (< phi_j | K) | c >
-                tmp = Ki_alpha[kid].conj().T @ Calpha[kid][:, :nmo_alpha]
-                # sum_j Binv_{ij} < phi_j | K | c > 
-                tmp = Binv_alpha_ace[kid] @ tmp 
-                # sum_i K | phi_i >  Binv_{ij} < phi_j | K | c >
-                ace_alpha = Ki_alpha[kid] @ tmp 
-
-                # < phi_j | K | c >
-                tmp = Ki_beta[kid].conj().T @ Cbeta[kid][:, :nmo_beta]
-                # sum_j Binv_{ij} < phi_j | K | c > 
-                tmp = Binv_beta_ace[kid] @ tmp 
-                # sum_i K | phi_i >  Binv_{ij} < phi_j | K | c >
-                ace_beta = Ki_beta[kid] @ tmp 
-
-                # is ace representation equivalent to original exact exchange representation?
-                assert (np.allclose(ace_alpha, exchange_alpha))
-                assert (np.allclose(ace_beta, exchange_beta))
-
-                Fa_c += ace_alpha
-                Fb_c += ace_beta
+                Fa_c += exchange_alpha
+                Fb_c += exchange_beta
             
             Fa_c += Vnl @ Calpha[kid][:, :nmo_alpha]
             Fb_c += Vnl @ Cbeta[kid][:, :nmo_beta]
@@ -1249,9 +1230,9 @@ def uks(cell, basis,
 
                 # (< phi_j | K) | c >
                 tmp = my_Ki.conj().T @ c
-                # sum_j Binv_{ij} < phi_j | K | c > 
-                tmp = my_Binv @ tmp 
-                # sum_i K | phi_i >  Binv_{ij} < phi_j | K | c >
+                # sum_j B_{ij} < phi_j | K | c > 
+                tmp = my_B @ tmp 
+                # sum_i K | phi_i >  B_{ij} < phi_j | K | c >
                 ace = my_Ki @ tmp 
 
                 if ace_exchange :
@@ -1278,14 +1259,14 @@ def uks(cell, basis,
                 occ_list = occ_alpha.copy()
                 my_v_r = v_alpha_r.copy()
                 my_Ki = Ki_alpha[kid].copy()
-                my_Binv = Binv_alpha_ace[kid].copy()
+                my_B = B_alpha_ace[kid].copy()
                 epsilon_alpha[kid], Calpha[kid] = scipy.sparse.linalg.lobpcg(F_C, Calpha[kid], largest=False, maxiter=2000, tol=d_convergence*0.1)
 
                 my_N = nbeta
                 occ_list = occ_beta.copy()
                 my_v_r = v_beta_r.copy()
                 my_Ki = Ki_beta[kid].copy()
-                my_Binv = Binv_beta_ace[kid].copy()
+                my_B = B_beta_ace[kid].copy()
                 epsilon_beta[kid], Cbeta[kid] = scipy.sparse.linalg.lobpcg(F_C, Cbeta[kid], largest=False, maxiter=2000, tol=d_convergence*0.1)
 
             else :

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -855,11 +855,11 @@ def uks(cell, basis,
 
     for kid in range ( len(basis.kpts) ):
 
-        #Calpha.append(np.random.rand(basis.n_plane_waves_per_k[kid], nalpha + 1) * 1e-8)
-        #Cbeta.append(np.random.rand(basis.n_plane_waves_per_k[kid], nbeta + 1) * 1e-8)
+        Calpha.append(np.random.rand(basis.n_plane_waves_per_k[kid], nalpha + 1) * 1e-8)
+        Cbeta.append(np.random.rand(basis.n_plane_waves_per_k[kid], nbeta + 1) * 1e-8)
 
-        Calpha.append(np.zeros((basis.n_plane_waves_per_k[kid], nalpha+1), dtype='complex128'))
-        Cbeta.append(np.zeros((basis.n_plane_waves_per_k[kid], nbeta+1), dtype='complex128'))
+        #Calpha.append(np.zeros((basis.n_plane_waves_per_k[kid], nalpha+1), dtype='complex128'))
+        #Cbeta.append(np.zeros((basis.n_plane_waves_per_k[kid], nbeta+1), dtype='complex128'))
 
         #Calpha[kid] = orthonormalize(Calpha[kid])
         #Cbeta[kid] = orthonormalize(Cbeta[kid])
@@ -1097,8 +1097,8 @@ def uks(cell, basis,
             ace_beta = Ki_beta[kid] @ tmp 
 
             # is ace representation equivalent to original exact exchange representation?
-            assert (np.allclose(ace_alpha, exchange_alpha))
-            assert (np.allclose(ace_beta, exchange_beta))
+            #assert (np.allclose(ace_alpha, exchange_alpha))
+            #assert (np.allclose(ace_beta, exchange_beta))
 
             Fa_c += ace_alpha
             Fb_c += ace_beta
@@ -1244,14 +1244,14 @@ def uks(cell, basis,
             my_v_r = v_alpha_r.copy()
             my_Ki = Ki_alpha[kid].copy()
             my_Binv = Binv_alpha_ace[kid].copy()
-            epsilon_alpha[kid], Calpha[kid] = scipy.sparse.linalg.eigsh(F_C, k=nalpha+1, which="SA")
+            epsilon_alpha[kid], Calpha[kid] = scipy.sparse.linalg.eigsh(F_C, k=nalpha+1, which="SA", v0 = Calpha[kid][:,0])
 
             my_N = nbeta
             occ_list = occ_beta.copy()
             my_v_r = v_beta_r.copy()
             my_Ki = Ki_beta[kid].copy()
             my_Binv = Binv_beta_ace[kid].copy()
-            epsilon_beta[kid], Cbeta[kid] = scipy.sparse.linalg.eigsh(F_C, k=nbeta+1, which="SA")
+            epsilon_beta[kid], Cbeta[kid] = scipy.sparse.linalg.eigsh(F_C, k=nbeta+1, which="SA", v0 = Cbeta[kid][:,0])
 
             #epsilon_alpha[kid], Calpha[kid] = scipy.linalg.eigh(fock_a[kid], eigvals=(0, nalpha))
             #epsilon_beta[kid], Cbeta[kid] = scipy.linalg.eigh(fock_b[kid], eigvals=(0, nbeta))

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -481,7 +481,7 @@ def get_nuclear_electronic_potential(cell, basis, valence_charges = None):
     # this is Z_{I} * S_{I}
     rhoG = np.dot(charges, basis.SI)  
 
-    coulG = np.divide(4.0 * np.pi, basis.g2, out = np.zeros_like(basis.g2), where = basis.g2 != 0.0)
+    coulG = 4.0 * np.pi * basis.inv_g2
 
     vneG = - rhoG * coulG / basis.omega
 
@@ -1014,7 +1014,7 @@ def uks(cell, basis,
     for myg in range( len(basis.g) ):
         inner_rhog[myg] = tmp[ get_miller_indices(myg, basis) ]
 
-    v_coulomb = 4.0 * np.pi * np.divide(inner_rhog, basis.g2, out = np.zeros_like(basis.g2), where = basis.g2 != 0.0)
+    v_coulomb = 4.0 * np.pi * inner_rhog * basis.inv_g2
 
     # jellium ... but only true in the thermodynamic limit
     if jellium:
@@ -1105,24 +1105,18 @@ def uks(cell, basis,
         if scf_iter < diis_start_cycle:
 
             # damping?
-            #v_alpha = (1.0-damp) * v_alpha + damp * v_alpha_old
-            #v_beta = (1.0-damp) * v_beta + damp * v_beta_old
             rho_alpha = (1.0-damp) * rho_alpha + damp * rho_alpha_old
             rho_beta = (1.0-damp) * rho_beta + damp * rho_beta_old
 
-
         solution_vector = np.hstack( (rho_alpha.flatten(), rho_beta.flatten()) )
-        #solution_vector = np.hstack( (v_alpha, v_beta) )
         new_solution_vector = diis.update(solution_vector, error_vector)
-        #v_alpha = new_solution_vector[:len(v_alpha)]
-        #v_beta = new_solution_vector[len(v_alpha):]
         rho_alpha = new_solution_vector[:len(solution_vector)//2].reshape(rho_alpha_old.shape)
         rho_beta = new_solution_vector[len(solution_vector)//2:].reshape(rho_beta_old.shape)
 
         rho_alpha.clip(min = 0)
         rho_beta.clip(min = 0)
 
-        # rebuild potentials
+        # recompute potentials
         rho = rho_alpha + rho_beta
 
         # coulomb potential
@@ -1130,7 +1124,7 @@ def uks(cell, basis,
         for myg in range( len(basis.g) ):
             inner_rhog[myg] = tmp[ get_miller_indices(myg, basis) ]
 
-        v_coulomb = 4.0 * np.pi * np.divide(inner_rhog, basis.g2, out = np.zeros_like(basis.g2), where = basis.g2 != 0.0)
+        v_coulomb = 4.0 * np.pi * inner_rhog * basis.inv_g2
 
         # jellium ... but only true in the thermodynamic limit
         if jellium:
@@ -1328,7 +1322,7 @@ def uks(cell, basis,
         for myg in range( len(basis.g) ):
             inner_rhog[myg] = tmp[ get_miller_indices(myg, basis) ]
 
-        v_coulomb = 4.0 * np.pi * np.divide(inner_rhog, basis.g2, out = np.zeros_like(basis.g2), where = basis.g2 != 0.0)
+        v_coulomb = 4.0 * np.pi * inner_rhog * basis.inv_g2
 
         # jellium ... but only true in the thermodynamic limit
         if jellium:

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -545,6 +545,7 @@ def get_density(basis, C, N, kid):
     :param kid: index for a given k-point
 
     :return rho: the density
+    :return occupied_orbitals: the occupied orbitals in real space 
 
     """
 
@@ -806,7 +807,7 @@ def uks(cell, basis,
     # damp fock matrix (helps with convergence sometimes)
     damping_factor = 1.0
     if damp_fock :
-        damping_factor = 0.5
+        damping_factor = 0.2
 
     # diis 
     diis_dimension = 6
@@ -850,6 +851,13 @@ def uks(cell, basis,
     epsilon_alpha = []
     epsilon_beta = []
 
+    # for ace
+    Binv_alpha_ace = []
+    Binv_beta_ace = []
+
+    Ki_alpha = []
+    Ki_beta = []
+
     for kid in range ( len(basis.kpts) ):
 
         fock_a.append(np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128'))
@@ -861,11 +869,20 @@ def uks(cell, basis,
         #Calpha.append(np.eye(basis.n_plane_waves_per_k[kid]))
         #Cbeta.append(np.eye(basis.n_plane_waves_per_k[kid]))
 
-        #Calpha.append(np.random.rand(basis.n_plane_waves_per_k[kid], nalpha + 1))
-        #Cbeta.append(np.random.rand(basis.n_plane_waves_per_k[kid], nbeta))
+        #Calpha.append(np.random.rand(basis.n_plane_waves_per_k[kid], nalpha + 1) * 1e-8)
+        #Cbeta.append(np.random.rand(basis.n_plane_waves_per_k[kid], nbeta + 1) * 1e-8)
 
         Calpha.append(np.zeros((basis.n_plane_waves_per_k[kid], nalpha+1), dtype='complex128'))
         Cbeta.append(np.zeros((basis.n_plane_waves_per_k[kid], nbeta+1), dtype='complex128'))
+
+        #Calpha[kid] = orthonormalize(Calpha[kid])
+        #Cbeta[kid] = orthonormalize(Cbeta[kid])
+
+        Binv_alpha_ace.append(np.zeros((nalpha, nalpha), dtype='complex128'))
+        Binv_beta_ace.append(np.zeros((nbeta, nbeta), dtype='complex128'))
+
+        Ki_alpha.append(np.zeros((basis.n_plane_waves_per_k[kid], nalpha), dtype='complex128'))
+        Ki_beta.append(np.zeros((basis.n_plane_waves_per_k[kid], nbeta), dtype='complex128'))
 
         epsilon_alpha.append(np.zeros((nalpha+1), dtype='complex128'))
         epsilon_beta.append(np.zeros((nbeta+1), dtype='complex128'))
@@ -925,6 +942,9 @@ def uks(cell, basis,
     v_beta = 0 * v_ne
     v_alpha_old = 0 * v_ne
     v_beta_old = 0 * v_ne
+
+    rho_alpha = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
+    rho_beta = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
 
     for scf_iter in range(maxiter):
 
@@ -999,7 +1019,13 @@ def uks(cell, basis,
                 tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
                 tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
 
-                Fa_c[:,i] = T[kid] * Calpha[kid][:, i] + tmp[basis.kg_to_g[kid]]
+                Fa_c[:,i] = T[kid] * Calpha[kid][:, i] + tmp[basis.kg_to_g[kid]] # map last term to small flattened basis
+
+                # for ace
+                tmp = Ki_r # real space, 3d
+                tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
+                tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
+                Ki_alpha[kid][:,i] = tmp[basis.kg_to_g[kid]] # reciprocal space, small flattened basis
 
             Fb_c = np.zeros((basis.n_plane_waves_per_k[kid], nbeta), dtype='complex128')
             for i in range (nbeta):
@@ -1024,17 +1050,63 @@ def uks(cell, basis,
                         # Ki(r) = sum_j Kij(r) phi_j(r)
                         Ki_r += Kij_r * occ_beta[j]
 
-                    Ki_r *= -4.0 * np.pi / basis.omega
+                    Ki_r *= -4.0 * np.pi / basis.omega 
 
                 # action of potential on orbitals in real space, then transform to reciprocal space
-                tmp = v_beta_r * occ_beta[i] + Ki_r # real space, 3d
+                tmp = v_beta_r * occ_beta[i] + Ki_r  # real space, 3d
                 tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
                 tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
 
-                Fb_c[:,i] = T[kid] * Cbeta[kid][:, i] + tmp[basis.kg_to_g[kid]]
+                Fb_c[:,i] = T[kid] * Cbeta[kid][:, i] + tmp[basis.kg_to_g[kid]] # map last term to small flattened basis
 
+                # for ace
+                tmp = Ki_r  # real space, 3d
+                tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
+                tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
+                Ki_beta[kid][:,i] = tmp[basis.kg_to_g[kid]] # reciprocal space, small flattened basis
+
+            # for ace < phi_i | Kj>^{-1}
+            if scf_iter > 0 :
+
+                tmp = -Calpha[kid][:, :nalpha].conj().T @ Ki_alpha[kid]
+                L = np.linalg.cholesky(tmp)
+                Linv = np.linalg.inv(L)
+                Binv_alpha_ace[kid] = -Linv.conj().T @ Linv
+
+                assert (np.allclose(-tmp @ Binv_alpha_ace[kid], np.eye(tmp.shape[0])))
+
+                tmp = -Cbeta[kid][:, :nbeta].conj().T @ Ki_beta[kid]
+                L = np.linalg.cholesky(tmp)
+                Linv = np.linalg.inv(L)
+                Binv_beta_ace[kid] = -Linv.conj().T @ Linv
+
+                assert (np.allclose(-tmp @ Binv_beta_ace[kid], np.eye(tmp.shape[0])))
+
+            else:
+                pass
+
+            # for ace
+
+            # (< phi_j | K) | c >
+            tmp = Ki_alpha[kid].conj().T @ Calpha[kid][:, :nalpha]
+            # sum_j Binv_{ij} < phi_j | K | c > 
+            tmp = Binv_alpha_ace[kid] @ tmp 
+            # sum_i K | phi_i >  Binv_{ij} < phi_j | K | c >
+            ace_alpha = Ki_alpha[kid] @ tmp 
+
+            # < phi_j | K | c >
+            tmp = Ki_beta[kid].conj().T @ Cbeta[kid][:, :nbeta]
+            # sum_j Binv_{ij} < phi_j | K | c > 
+            tmp = Binv_beta_ace[kid] @ tmp 
+            # sum_i K | phi_i >  Binv_{ij} < phi_j | K | c >
+            ace_beta = Ki_beta[kid] @ tmp 
+
+            #Fa_c += ace_alpha
+            #Fb_c += ace_beta
+            
             Fa_c += Vnl @ Calpha[kid][:, :nalpha]
             Fb_c += Vnl @ Cbeta[kid][:, :nbeta]
+
             #grad_a = Fa_c - epsilon_alpha[kid][np.newaxis, :nalpha] * Calpha[kid][:,:nalpha]
             #grad_b = Fb_c - epsilon_beta[kid][np.newaxis, :nbeta] * Cbeta[kid][:,:nbeta]
 
@@ -1061,7 +1133,7 @@ def uks(cell, basis,
         # norm of orbital gradient
         conv = np.linalg.norm(error_vector)
 
-        # damp or extrapolate solution vector
+        # damp or extrapolate potential
         if scf_iter < diis_start_cycle:
 
             # damping?
@@ -1076,6 +1148,54 @@ def uks(cell, basis,
             new_solution_vector = inner_diis.update(solution_vector, error_vector)
             v_alpha = new_solution_vector[:len(v_alpha)]
             v_beta = new_solution_vector[len(v_alpha):]
+
+        #rho_alpha_old = rho_alpha.copy()
+        #rho_beta_old = rho_beta.copy()
+
+        ## damp or extrapolate density
+        #if scf_iter < diis_start_cycle:
+
+        #    # damping?
+        #    rho_alpha = (1.0-damp) * rho_alpha + damp * rho_alpha_old
+        #    rho_beta = (1.0-damp) * rho_beta + damp * rho_beta_old
+
+        #else :
+
+        #    #v_coulomb = inner_diis.update(v_coulomb, error_vector)
+
+        #    solution_vector = np.hstack( (rho_alpha.flatten(), rho_beta.flatten()) )
+        #    new_solution_vector = inner_diis.update(solution_vector, error_vector)
+        #    rho_alpha = new_solution_vector[:len(solution_vector)//2].reshape(rho_alpha_old.shape).real
+        #    rho_beta = new_solution_vector[len(solution_vector)//2:].reshape(rho_beta_old.shape).real
+
+        #rho_alpha = rho_alpha.clip(min = 0)
+        #rho_beta = rho_beta.clip(min = 0)
+
+        ## need to rebuild potential
+        #rho = rho_alpha + rho_beta
+
+        ## coulomb potential
+        #tmp = np.fft.ifftn(rho)
+        #for myg in range( len(basis.g) ):
+        #    inner_rhog[myg] = tmp[ get_miller_indices(myg, basis) ]
+
+        #v_coulomb = 4.0 * np.pi * np.divide(inner_rhog, basis.g2, out = np.zeros_like(basis.g2), where = basis.g2 != 0.0)
+
+        ## exchange-correlation potential
+        #if xc != 'hf' :
+
+        #    v_xc_alpha, v_xc_beta = get_xc_potential(xc, basis, rho_alpha, rho_beta, libxc_x_functional, libxc_c_functional)
+        #    xc_energy = get_xc_energy(xc, basis, rho_alpha, rho_beta, libxc_x_functional, libxc_c_functional)
+
+        #else :
+
+        #    # we'll deal with hf exchange matrices on the fly ... here, just get the energy
+        #    xc_energy, exchange_matrix_alpha = get_exact_exchange_energy(basis, occ_alpha, nalpha, Calpha, exchange_matrix_alpha, False)
+        #    if nbeta > 0:
+        #        my_xc_energy, exchange_matrix_beta = get_exact_exchange_energy(basis, occ_beta, nbeta, Cbeta, exchange_matrix_beta, False)
+        #        xc_energy += my_xc_energy
+        #    xc_energy -= 0.5 * (nalpha + nbeta) * madelung
+
 
         #fock_a[kid] = form_fock_matrix(basis, kid, v = v_alpha + v_ne) + Vnl + exchange_matrix_alpha
         #fock_b[kid] = form_fock_matrix(basis, kid, v = v_beta + v_ne) + Vnl + exchange_matrix_beta
@@ -1092,13 +1212,18 @@ def uks(cell, basis,
         one_electron_energy = 0.0
         coulomb_energy = 0.0
 
-        rho_a = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
-        rho_b = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
+        rho_alpha = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
+        rho_beta = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
 
         # diagonalize fock matrix with extrapolated potential
         Kij_G = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
 
         for kid in range ( len(basis.kpts) ):
+
+            Vnl = get_nonlocal_pseudopotential_matrix_elements(basis, kid, use_legendre = basis.nl_pp_use_legendre)
+            Vnl = Vnl + Vnl.conj().T
+            diag = np.diag(Vnl)
+            np.fill_diagonal(Vnl, 0.5 * diag)
 
             def apply_fock_operator_to_orbital(c):
                 """
@@ -1121,7 +1246,6 @@ def uks(cell, basis,
 
                 # exchange
                 Ki_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
-
                 if xc == 'hf' :
                     for j in range(0, my_N):
 
@@ -1143,11 +1267,32 @@ def uks(cell, basis,
                     Ki_r *= -4.0 * np.pi / basis.omega
 
                 # action of potential on orbitals in real space, then transform to reciprocal space
-                tmp = my_v_r * occ + Ki_r # real space, 3d
+                tmp = my_v_r * occ  # real space, 3d
                 tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
                 tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
 
                 F_c = T[kid] * c + tmp[basis.kg_to_g[kid]] + Vnl @ c
+
+                # for ace
+
+                # (< phi_j | K) | c >
+                tmp = my_Ki.conj().T @ c
+                # sum_j Binv_{ij} < phi_j | K | c > 
+                tmp = my_Binv @ tmp 
+                # sum_i K | phi_i >  Binv_{ij} < phi_j | K | c >
+                ace = my_Ki @ tmp 
+
+                #F_c += ace
+
+                # exact exchange
+                tmp = Ki_r # real space, 3d
+                tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
+                tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
+                tmp = tmp[basis.kg_to_g[kid]] # reciprocal space, small flattened basis
+
+                F_c += tmp
+                
+                #print(np.linalg.norm(ace - tmp))
 
                 #assert np.allclose(F_c, fock_a[kid] @ c)
                 #print(np.linalg.norm(F_c - fock_a[kid] @ c))
@@ -1163,11 +1308,15 @@ def uks(cell, basis,
             my_N = nalpha
             occ_list = occ_alpha.copy()
             my_v_r = v_alpha_r.copy()
+            my_Ki = Ki_alpha[kid].copy()
+            my_Binv = Binv_alpha_ace[kid].copy()
             epsilon_alpha[kid], Calpha[kid] = scipy.sparse.linalg.eigsh(F_C, k=nalpha+1, which="SA")
 
             my_N = nbeta
             occ_list = occ_beta.copy()
             my_v_r = v_beta_r.copy()
+            my_Ki = Ki_beta[kid].copy()
+            my_Binv = Binv_beta_ace[kid].copy()
             epsilon_beta[kid], Cbeta[kid] = scipy.sparse.linalg.eigsh(F_C, k=nbeta+1, which="SA")
 
             #epsilon_alpha[kid], Calpha[kid] = scipy.linalg.eigh(fock_a[kid], eigvals=(0, nalpha))
@@ -1193,12 +1342,12 @@ def uks(cell, basis,
             #    Calpha[kid][:, nalpha] = tmp2
 
             # update density
-            my_rho_a, occ_alpha = get_density(basis, Calpha[kid], nalpha, kid)
-            my_rho_b, occ_beta = get_density(basis, Cbeta[kid], nbeta, kid)
+            my_rho_alpha, occ_alpha = get_density(basis, Calpha[kid], nalpha, kid)
+            my_rho_beta, occ_beta = get_density(basis, Cbeta[kid], nbeta, kid)
 
             # density should be non-negative ...
-            rho_a += my_rho_a.clip(min = 0)
-            rho_b += my_rho_b.clip(min = 0)
+            rho_alpha += my_rho_alpha.clip(min = 0)
+            rho_beta += my_rho_beta.clip(min = 0)
 
             # one-electron part of the energy (alpha)
             one_electron_energy += get_one_electron_energy(basis, 
@@ -1220,7 +1369,7 @@ def uks(cell, basis,
             # coulomb part of the energy: 1/2 J
             coulomb_energy += get_coulomb_energy(basis, Cbeta[kid], nbeta, kid, v_coulomb)
 
-        rho = rho_a + rho_b
+        rho = rho_alpha + rho_beta
 
         # coulomb potential
         tmp = np.fft.ifftn(rho)
@@ -1232,8 +1381,8 @@ def uks(cell, basis,
         # exchange-correlation potential
         if xc != 'hf' :
 
-            v_xc_alpha, v_xc_beta = get_xc_potential(xc, basis, rho_a, rho_b, libxc_x_functional, libxc_c_functional)
-            xc_energy = get_xc_energy(xc, basis, rho_a, rho_b, libxc_x_functional, libxc_c_functional)
+            v_xc_alpha, v_xc_beta = get_xc_potential(xc, basis, rho_alpha, rho_beta, libxc_x_functional, libxc_c_functional)
+            xc_energy = get_xc_energy(xc, basis, rho_alpha, rho_beta, libxc_x_functional, libxc_c_functional)
 
         else :
 

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -594,39 +594,28 @@ def form_fock_matrix(basis, kid, v = None):
 
     return fock
 
-def get_one_electron_energy(basis, C, N, kid, v_ne = None, jellium = False):
+# TODO: eliminate npw x npw storage
+def get_nonlocal_pp_energy(basis, C, N, kid):
     """
 
-    get one-electron part of the energy
+    get nonlocal pseudopotential part of the energy
 
     :param basis: plane wave basis information
     :param C: molecular orbital coefficients
     :param N: the number of electrons
     :param kid: index for a given k-point
-    :param v_ne: nuclear electron potential or local part of the pseudopotential
 
-    :return one_electron_energy: the one-electron energy
+    :return one_electron_energy: the nonlocal pseudopotential part of the energy
 
     """
 
     # oei = T + V 
     oei = np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128')
 
-    # jellium
-    if not jellium:
-        if v_ne is not None:
-            oei += get_matrix_elements(basis, kid, v_ne)
-
-        if basis.use_pseudopotential:
-            oei += get_nonlocal_pseudopotential_matrix_elements(basis, kid, use_legendre = basis.nl_pp_use_legendre)
-
-    kgtmp = basis.kpts[kid] + basis.g[basis.kg_to_g[kid, :basis.n_plane_waves_per_k[kid]]]
-    T = np.einsum('ij,ij->i', kgtmp, kgtmp) / 2.0 
-    diagonals = T + oei.diagonal()
-    np.fill_diagonal(oei, diagonals)
+    if basis.use_pseudopotential:
+        oei = get_nonlocal_pseudopotential_matrix_elements(basis, kid, use_legendre = basis.nl_pp_use_legendre)
 
     oei = oei + oei.conj().T
-
     diag = np.diag(oei)
     np.fill_diagonal(oei, 0.5 * diag)
 
@@ -634,9 +623,9 @@ def get_one_electron_energy(basis, C, N, kid, v_ne = None, jellium = False):
     for pp in range(N):
         tmporbs[:, pp] = C[:, pp]
 
-    one_electron_energy = np.einsum('pi,pq,qi->',tmporbs.conj(), oei, tmporbs) / len(basis.kpts)
+    nonlocal_pp_energy = np.einsum('pi,pq,qi->',tmporbs.conj(), oei, tmporbs) / len(basis.kpts)
 
-    return one_electron_energy
+    return nonlocal_pp_energy
 
 def fock_on_orbitals(basis, kid, ne, nmo, occ, C, T, v_r, Vnl, xc):
     """
@@ -1239,21 +1228,21 @@ def uks(cell, basis,
             rho_alpha += my_rho_alpha.clip(min = 0)
             rho_beta += my_rho_beta.clip(min = 0)
 
-            # one-electron part of the energy (alpha)
-            one_electron_energy += get_one_electron_energy(basis, 
-                                                           Calpha[kid], 
-                                                           nalpha, 
-                                                           kid, 
-                                                           v_ne = v_ne,
-                                                           jellium = jellium)
+            # kinetic energy part of the one-electron energy
+            one_electron_energy += np.sum(np.einsum('pi,p->i', np.abs(Calpha[kid][:,:nalpha])**2, T[kid]))
+            one_electron_energy += np.sum(np.einsum('pi,p->i', np.abs(Cbeta[kid][:,:nbeta])**2, T[kid]))
 
-            # one-electron part of the energy (beta)
-            one_electron_energy += get_one_electron_energy(basis, 
-                                                           Cbeta[kid], 
-                                                           nbeta, 
-                                                           kid, 
-                                                           v_ne = v_ne,
-                                                           jellium = jellium)
+            # nonlocal pseudopotential part of the energy
+            if not jellium:
+                one_electron_energy += get_nonlocal_pp_energy(basis, Calpha[kid], nalpha, kid)
+                one_electron_energy += get_nonlocal_pp_energy(basis, Cbeta[kid], nbeta, kid)
+
+        # nuclear potential / local pseudopotential part of the one-electron energy
+        if not jellium:
+            v_ne_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
+            v_ne_r.ravel()[basis.flat_idx] = v_ne
+            v_ne_r = np.fft.fftn(v_ne_r).real
+            one_electron_energy += ( basis.omega / ( basis.real_space_grid_dim[0] * basis.real_space_grid_dim[1] * basis.real_space_grid_dim[2] ) ) * np.sum((rho_alpha + rho_beta) * v_ne_r)
 
         # coulomb part of the energy: 1/2 J
         v_coulomb_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -794,7 +794,7 @@ def uks(cell, basis,
     # damp fock matrix (helps with convergence sometimes)
     damping_factor = 1.0
     if damp_fock :
-        damping_factor = 0.90
+        damping_factor = 0.50
 
     # diis 
     diis_dimension = 8

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -696,7 +696,7 @@ def compute_local_potentials(rho_alpha, rho_beta, v_ne, basis, xc, libxc_x_funct
 
     v_coulomb = 4.0 * np.pi * rhog * basis.inv_g2
 
-    # jellium ... but only true in the thermodynamic limit
+    # jellium ... but only true in the thermodynamic limit ... or if we want the uniform density
     #if jellium:
     #    v_coulomb *= 0.0
 
@@ -780,60 +780,64 @@ def find_chemical_potential(ne, eps, kBT = None, tol=1e-10, maxit = 200):
 
     return mu_mid
 
-def kerker_preconditioning(rho_alpha, rho_beta, rho_alpha_old, rho_beta_old, basis, ne, q0 = None, alpha = 0.05):
+def kerker_preconditioning(rho_alpha_out, rho_beta_out, rho_alpha_in, rho_beta_in, basis, ne, q0=None, alpha=0.05):
     """
-    kerker preconditioning
+    Kerker preconditioning.
     
-    :param rho_alpha: current alpha-spin density 
-    :param rho_beta: current beta-spin density
-    :param rho_alpha_old: previous alpha-spin density 
-    :param rho_beta_old: previous beta-spin density
+    :param rho_alpha_out: current output alpha-spin density (real space)
+    :param rho_beta_out: current output beta-spin density (real space)
+    :param rho_alpha_in: previous input alpha-spin density (real space)
+    :param rho_beta_in: previous input beta-spin density (real space)
     :param basis: the plane-wave basis object
     :param ne: number of electrons
-    :param q0: screening length. if None, chosen to be the Fermi wavevector for jellium
-    :param alpha: mixing parameter. default should be good for metallic systems
+    :param q0: screening length. if None, chosen to be the Thomas-Fermi wavevector
+    :param alpha: mixing parameter
     """
 
-    # 1. densities in reciprocal space
-    tmp_alpha = np.fft.ifftn(rho_alpha)
-    rho_alpha_G_new = tmp_alpha.ravel()[basis.flat_idx]
+    # 1. transform densities to reciprocal space
+    rhoG_alpha_out_full = np.fft.ifftn(rho_alpha_out)
+    rhoG_alpha_in_full = np.fft.ifftn(rho_alpha_in)
+    rhoG_beta_out_full = np.fft.ifftn(rho_beta_out)
+    rhoG_beta_in_full = np.fft.ifftn(rho_beta_in)
 
-    tmp_alpha = np.fft.ifftn(rho_alpha_old)
-    rho_alpha_G_old = tmp_alpha.ravel()[basis.flat_idx]
+    rhoG_alpha_out = rhoG_alpha_out_full.ravel()[basis.flat_idx]
+    rhoG_alpha_in = rhoG_alpha_in_full.ravel()[basis.flat_idx]
+    rhoG_beta_out = rhoG_beta_out_full.ravel()[basis.flat_idx]
+    rhoG_beta_in = rhoG_beta_in_full.ravel()[basis.flat_idx]
 
-    tmp_beta = np.fft.ifftn(rho_beta)
-    rho_beta_G_new = tmp_beta.ravel()[basis.flat_idx]
+    # 2. calculate residual in reciprocal space
+    res_alpha_G = rhoG_alpha_out - rhoG_alpha_in
+    res_beta_G = rhoG_beta_out - rhoG_beta_in
 
-    tmp_beta = np.fft.ifftn(rho_beta_old)
-    rho_beta_G_old = tmp_beta.ravel()[basis.flat_idx]
-
-    # 2. residual in reciprocal space
-    res_alpha_G = rho_alpha_G_new - rho_alpha_G_old
-    res_beta_G = rho_beta_G_new - rho_beta_G_old
-
-    # 3. preconditioner
+    # 3. define the preconditioner (HIGH-PASS FILTER)
     if q0 is None:
-        q0 = np.sqrt(4.0/np.pi) * (3.0 * np.pi**2 * ne / basis.omega)**(1.0/6.0) # for jellium
+        # Thomas-Fermi screening wavevector for jellium
+        q0 = np.sqrt(4.0 / np.pi) * (3.0 * np.pi**2 * ne / basis.omega)**(1.0 / 6.0)
+
     P = basis.g2 / (basis.g2 + q0**2)
-    P[0] = 0.0
 
-    res_alpha_G_pre = res_alpha_G * P
-    res_beta_G_pre = res_beta_G * P
+    # 4. apply preconditioned update to get the mixed density in reciprocal space
+    rhoG_alpha_mixed = rhoG_alpha_in + alpha * P * res_alpha_G
+    rhoG_beta_mixed = rhoG_beta_in + alpha * P * res_beta_G
 
-    # 4. new density in reciprocal space
-    rho_alpha_G_new = rho_alpha_G_old + alpha * res_alpha_G_pre
-    rho_beta_G_new = rho_beta_G_old + alpha * res_beta_G_pre
+    shape = rhoG_alpha_out_full.shape
+    rhoG_alpha_full = np.zeros(shape, dtype=complex).ravel()
+    rhoG_beta_full = np.zeros(shape, dtype=complex).ravel()
 
-    # 5. new density in real space wtf
-    tmp_alpha.ravel()[basis.flat_idx] = rho_alpha_G_new
-    rho_alpha = np.fft.fftn(tmp_alpha).real
-    rho_alpha.clip(min = 0)
+    rhoG_alpha_full[basis.flat_idx] = rhoG_alpha_mixed
+    rhoG_beta_full[basis.flat_idx] = rhoG_beta_mixed
 
-    tmp_beta.ravel()[basis.flat_idx] = rho_beta_G_new
-    rho_beta = np.fft.fftn(tmp_beta).real
-    rho_beta.clip(min = 0)
+    rhoG_alpha_full = rhoG_alpha_full.reshape(shape)
+    rhoG_beta_full = rhoG_beta_full.reshape(shape)
 
-    return rho_alpha, rho_beta
+    # 5. transform back to real space
+    rho_alpha_next = np.fft.ifftn(rhoG_alpha_full).real
+    rho_beta_next = np.fft.ifftn(rhoG_beta_full).real
+
+    np.maximum(rho_alpha_next, 0.0, out=rho_alpha_next)
+    np.maximum(rho_beta_next, 0.0, out=rho_beta_next)
+    
+    return rho_alpha_next, rho_beta_next
 
 def uks(cell, basis, 
         xc = 'lda', 
@@ -845,9 +849,9 @@ def uks(cell, basis,
         jellium = False,
         jellium_ne = 2,
         maxiter=500,
-        kBT=None,
-        kerker_q0=None,
-        kerker_alpha=0.05):
+        kBT=None):
+        #kerker_q0=None,
+        #kerker_alpha=0.05):
 
     """
 
@@ -864,10 +868,10 @@ def uks(cell, basis,
     :return Calpha: alpha MO coefficients
     :return Cbeta: beta MO coefficients
     :return kBT: boltzman factor times temperature (for smearing)
-    :param kerker_q0: screening length for kerker preconditioning. if None, chosen to be the Fermi wavevector for jellium
-    :param kerker_alpha: kerker mixing parameter. default should be good for metallic systems
 
     """
+    # :param kerker_q0: screening length for kerker preconditioning. if None, chosen to be the Fermi wavevector for jellium
+    # :param kerker_alpha: kerker mixing parameter. default should be good for metallic systems
 
     print('')
     print('    ************************************************')
@@ -931,9 +935,10 @@ def uks(cell, basis,
 
     # nmo ... number of desired molecular orbitals ... must be at least ne
     nmo_alpha = nalpha #+ 1
-    nmo_beta = nbeta #nbeta #+ 1
+    nmo_beta = nbeta #+ 1
     #if guess_mix:
     #    nmo_alpha += 1
+    #    nmo_beta += 1
     
     # increase nmo if we're doing smearing
     if kBT is not None:
@@ -961,9 +966,9 @@ def uks(cell, basis,
     print('    no. total beta bands:                        %20i' % ( nmo_beta ) )
     print('    break spin symmetry:                         %20s' % ( "yes" if guess_mix is True else "no" ) )
     print('    no. diis vectors:                            %20i' % ( diis_dimension ) )
-    if kerker_q0 is not None:
-        print('    kerker screening length                      %20.2f' % ( kerker_q0) )
-    print('    kerker mixing parameter                      %20.2f' % ( kerker_alpha) )
+    #if kerker_q0 is not None:
+    #    print('    kerker screening length                      %20.2f' % ( kerker_q0) )
+    #print('    kerker mixing parameter                      %20.2f' % ( kerker_alpha) )
 
     if guess_mix :
         print("")
@@ -1010,8 +1015,8 @@ def uks(cell, basis,
 
     for kid in range ( len(basis.kpts) ):
 
-        #Calpha.append(np.random.rand(basis.n_plane_waves_per_k[kid], nmo_alpha) * 1e-8)
-        #Cbeta.append(np.random.rand(basis.n_plane_waves_per_k[kid], nmo_beta) * 1e-8)
+        #Calpha.append(np.random.rand(basis.n_plane_waves_per_k[kid], nmo_alpha) * 1e-4)
+        #Cbeta.append(np.random.rand(basis.n_plane_waves_per_k[kid], nmo_beta) * 1e-4)
         Calpha.append(np.zeros((basis.n_plane_waves_per_k[kid], nmo_alpha), dtype='complex128'))
         Cbeta.append(np.zeros((basis.n_plane_waves_per_k[kid], nmo_beta), dtype='complex128'))
         for i in range (nmo_alpha):
@@ -1032,14 +1037,20 @@ def uks(cell, basis,
 
         # jellium orbital guess, plus some noise
         if jellium:
-            eps_a, ca = np.linalg.eigh(np.diag(T[kid]))
 
+            #lowest_energy_T_index = np.argsort(T[kid])[:nalpha]
+            #epsilon_alpha[kid] = T[kid][lowest_energy_T_index]
+            #Calpha[kid] = np.zeros((len(T[kid]), nalpha), dtype=np.complex128)
+            #for orb_idx, pw_idx in enumerate(lowest_energy_T_index):
+            #    Calpha[kid][pw_idx, orb_idx] = 1.0
+
+            eps_a, ca = np.linalg.eigh(np.diag(T[kid]))
             epsilon_alpha[kid], Calpha[kid] = eps_a[:nmo_alpha], ca[:, :nmo_alpha]
             # mix in other plane waves? 
             #for j in range (0, nmo_alpha):
-            #    Calpha[kid][:, j] += 1e-5 * ca[:, nmo_alpha + j] 
+            #    Calpha[kid][:, j] += 1e-3 * ca[:, nmo_alpha + j] 
 
-            Calpha[kid] += np.random.rand(basis.n_plane_waves_per_k[kid], nmo_alpha) * 1e-5
+            #Calpha[kid] += np.random.rand(basis.n_plane_waves_per_k[kid], nmo_alpha) * 1e-3
             Calpha[kid] = orthonormalize(Calpha[kid])
             Cbeta[kid] = Calpha[kid].copy()
             #one_electron_energy = np.sum(np.einsum('pi,p->i', np.abs(Calpha[kid][:,:nalpha])**2, T[kid]))
@@ -1075,9 +1086,18 @@ def uks(cell, basis,
             one_electron_energy = 0.0
             coulomb_energy = 0.0
 
-            # compute local potentials
-            v_coulomb, v_alpha_r, v_beta_r = compute_local_potentials(rho_alpha, rho_beta, v_ne, basis, xc, libxc_x_functional, libxc_c_functional, jellium)
+            # kerker preconditioning
+            #rho_alpha, rho_beta = kerker_preconditioning(rho_alpha, rho_beta, rho_alpha_old, rho_beta_old, basis, nalpha + nbeta, q0 = kerker_q0, alpha = kerker_alpha)
+            #print(np.linalg.norm(new_rho_alpha-rho_alpha), np.linalg.norm(new_rho_beta-rho_beta))
 
+            # damping
+            damp = 0.5
+            if scf_iter > 0:
+                rho_alpha = rho_alpha_old * (1.0 - damp) + rho_alpha * damp
+                rho_beta = rho_beta_old * (1.0 - damp) + rho_beta * damp
+
+                # compute local potentials
+                v_coulomb, v_alpha_r, v_beta_r = compute_local_potentials(rho_alpha, rho_beta, v_ne, basis, xc, libxc_x_functional, libxc_c_functional, jellium)
             # evaluate the orbital gradient
             error_vector = np.zeros(0)
             for kid in range( len(basis.kpts) ):
@@ -1119,9 +1139,6 @@ def uks(cell, basis,
             # norm of the orbital gradient for convergence check
             conv = np.linalg.norm(error_vector)
 
-            # kerker preconditioning
-            rho_alpha, rho_beta = kerker_preconditioning(rho_alpha, rho_beta, rho_alpha_old, rho_beta_old, basis, nalpha + nbeta, q0 = kerker_q0, alpha = kerker_alpha)
-
             solution_vector = np.hstack( (rho_alpha.flatten(), rho_beta.flatten()) )
             new_solution_vector = diis.update(solution_vector, error_vector)
 
@@ -1131,7 +1148,7 @@ def uks(cell, basis,
             rho_alpha = rho_alpha.clip(min = 0).real
             rho_beta = rho_beta.clip(min = 0).real
 
-            # recompute potentials after kerker preconditioning and diis extrapolation
+            # recompute potentials after diis extrapolation
             v_coulomb, v_alpha_r, v_beta_r = compute_local_potentials(rho_alpha, rho_beta, v_ne, basis, xc, libxc_x_functional, libxc_c_functional, jellium)
 
             one_electron_energy = 0.0

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -918,8 +918,8 @@ def uks(cell, basis,
     # madelung correction
     madelung = tools.pbc.madelung(cell, basis.kpts)
 
-    #nalpha, nbeta = cell.nelec
-    nbeta, nalpha = cell.nelec
+    nalpha, nbeta = cell.nelec
+    #nbeta, nalpha = cell.nelec
     total_charge = cell.charge
 
     # jellium

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -88,92 +88,6 @@ def get_exact_exchange_energy(basis, occupied_orbitals, N, C):
 
     return -2.0 * np.pi / basis.omega * exchange_energy
 
-
-def get_exact_exchange_potential(basis, occupied_orbitals, N, C):
-    """
-
-    evaluate the exact Hartree-Fock exchange energy, according to
-
-        Ex = - 2 pi / Omega sum_{mn in occ} sum_{g} |Cmn(g)|^2 / |g|^2
-
-    where
-
-        Cmn(g) = FT[ phi_m(r) phi_n*(r) ]
-
-    see JCP 108, 4697 (1998) for more details.
-
-    :param basis: plane wave basis information
-    :param occupied_orbitals: a list of occupied orbitals
-    :param N: the number of electrons
-    :param N: the MO transformation matrix
-
-    :return exchange_energy: the exact Hartree-Fock exchange energy
-    :return exchange_potential: the exact Hartree-Fock exchange potential
-
-    """
-
-    # accumulate exchange energy and matrix
-    exchange_energy = 0.0
-
-    for i in range(0, N):
-        for j in range(0, N):
-
-            # Cij(r') = phi_i(r') phi_j*(r')
-            # Cij(g) = FFT[Cij(r')]
-            tmp = np.fft.ifftn(occupied_orbitals[j].conj() * occupied_orbitals[i])
-            Cij = tmp.ravel()[basis.flat_idx]
-
-            # Kij(g) = Cij(g) * FFT[1/|r-r'|]
-            Kij = Cij * basis.inv_g2
-
-            exchange_energy += np.sum( Cij.conj() * Kij )
-
-    # build exchange matrix in planewave basis
-    exchange_matrix = np.zeros((basis.n_plane_waves_per_k[0], basis.n_plane_waves_per_k[0]), dtype='complex128')
-
-    Kij_G = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
-
-    for i in range(0, basis.n_plane_waves_per_k[0]):
-        ii = basis.kg_to_g[0][i]
-
-        # Ki(r) = sum_j Kij(r) phi_j(r)
-        Ki_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
-
-        # a planewave basis function
-        phi_i = np.zeros(len(basis.g), dtype = 'complex128')
-        phi_i[ii] = 1.0
-        tmp = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
-        #for myg in range( len(basis.g) ):
-        #    tmp[ get_miller_indices(myg, basis) ] = phi_i[myg]
-        tmp.ravel()[basis.flat_idx] = phi_i
-        phi_i = np.fft.fftn(tmp)
-
-        for j in range(0, N):
-
-            # Cij(r') = phi_i(r') phi_j*(r')
-            # Cij(g) = FFT[Cij(r')]
-            tmp = np.fft.ifftn(occupied_orbitals[j].conj() * phi_i)
-            Cij = tmp.ravel()[basis.flat_idx]
-
-            # Kij(g) = Cij(g) * FFT[1/|r-r'|]
-            Kij_G.ravel()[basis.flat_idx] = Cij * basis.inv_g2 #Kij
-
-            # Kij(r) = FFT^-1[Kij(g)]
-            Kij_r = np.fft.fftn(Kij_G)
-
-            # action of K on an occupied orbital, i: 
-            # Ki(r) = sum_j Kij(r) phi_j(r)
-            Ki_r += Kij_r * occupied_orbitals[j]
-
-        # build a row of the exchange matrix: < G' | K | G''> = FFT( Ki_r )
-        row_g = np.fft.ifftn(Ki_r)
-        for k in range(0, basis.n_plane_waves_per_k[0]):
-            kk = basis.kg_to_g[0][k]
-            
-            exchange_matrix[k, i] = row_g[ get_miller_indices(kk, basis) ] 
-
-    return -2.0 * np.pi / basis.omega * exchange_energy, -4.0 * np.pi / basis.omega * exchange_matrix
-
 def get_xc_potential(xc, basis, rho_alpha, rho_beta, libxc_x_functional, libxc_c_functional):
     """
 
@@ -338,11 +252,6 @@ def get_xc_potential(xc, basis, rho_alpha, rho_beta, libxc_x_functional, libxc_c
             v_xc_alpha[myg] = tmp_alpha[ get_miller_indices(myg, basis) ]
             v_xc_beta[myg] = tmp_beta[ get_miller_indices(myg, basis) ]
 
-    else :
-
-        # TODO: fix for general k
-        xc_energy = get_exact_exchange_energy(basis, occupied_orbitals, N, C)
-
     return v_xc_alpha, v_xc_beta
 
 def get_xc_energy(xc, basis, rho_alpha, rho_beta, libxc_x_functional, libxc_c_functional): 
@@ -429,6 +338,7 @@ def get_xc_energy(xc, basis, rho_alpha, rho_beta, libxc_x_functional, libxc_c_fu
 
     return xc_energy
 
+# TODO: we won't need this function once storage of non-local pseudopotential matrix is eliminated
 def get_matrix_elements(basis, kid, vg):
 
     """
@@ -487,42 +397,6 @@ def get_nuclear_electronic_potential(cell, basis, valence_charges = None):
 
     return vneG
 
-def form_orbital_gradient(basis, C, N, F, kid):
-    """
-
-    form density matrix and orbital gradient from fock matrix and orbital coefficients
-
-    :param basis: plane wave basis information
-    :param C: molecular orbital coefficients
-    :param N: the number of electrons
-    :param F: the fock matrix
-    :param kid: index for a given k-point
-
-    :return orbital_gradient: the orbital gradient
-
-    """
-
-    tmporbs = np.zeros([basis.n_plane_waves_per_k[kid], N], dtype = 'complex128')
-    for pp in range(N):
-        tmporbs[:, pp] = C[:, pp]
-
-    #D = np.einsum('ik,jk->ij', tmporbs.conj(), tmporbs)
-    D = np.matmul(tmporbs, tmporbs.conj().T) 
-
-    # only upper triangle of F is populated ... symmetrize and rescale diagonal
-    #F = F + F.conj().T
-    #diag = np.diag(F)
-    #np.fill_diagonal(F, 0.5 * diag)
-    #for pp in range(basis.n_plane_waves_per_k[kid]):
-    #    F[pp][pp] *= 0.5
-
-    #orbital_gradient = np.einsum('ik,kj->ij', F, D)
-    #orbital_gradient -= np.einsum('ik,kj->ij', D, F)
-    orbital_gradient = np.matmul(F, D)
-    orbital_gradient -= np.matmul(D, F)
-
-    return orbital_gradient
-
 def get_density(basis, C, Ne, Nmo, kid):
     """
 
@@ -557,42 +431,6 @@ def get_density(basis, C, Ne, Nmo, kid):
             rho += np.absolute(occ)**2.0 / basis.omega
 
     return ( 1.0 / len(basis.kpts) ) * rho, orbitals_r
-
-def form_fock_matrix(basis, kid, v = None): 
-    """
-
-    form fock matrix
-
-    :param basis: plane wave basis information
-    :param kid: index for a given k-point
-    :param v: the potential ( coulomb + xc + electron-nucleus / local pp )
-
-    :return fock: the fock matrix
-
-    """
-
-    fock = np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128')
-
-    # unpack potential
-    if v is not None:
-        fock += get_matrix_elements(basis, kid, v)
-    
-    # get non-local part of the pseudopotential (not jellium)
-    if basis.use_pseudopotential and not jellium:
-        fock += get_nonlocal_pseudopotential_matrix_elements(basis, kid, use_legendre = basis.nl_pp_use_legendre)
-
-    # get kinetic energy
-    kgtmp = basis.kpts[kid] + basis.g[basis.kg_to_g[kid, :basis.n_plane_waves_per_k[kid]]]
-    T = np.einsum('ij,ij->i', kgtmp, kgtmp) / 2.0 
-    diagonals = T + fock.diagonal()
-    np.fill_diagonal(fock, diagonals)
-
-    # only upper triangle of fock is populated ... symmetrize and rescale diagonal
-    fock = fock + fock.conj().T
-    diag = np.diag(fock)
-    np.fill_diagonal(fock, 0.5 * diag)
-
-    return fock
 
 # TODO: eliminate npw x npw storage
 def get_nonlocal_pp_energy(basis, C, N, kid):
@@ -1052,8 +890,8 @@ def uks(cell, basis,
         epsilon_beta.append(np.zeros((nmo_beta), dtype='complex128'))
 
     # initialize occ_alpha and occ_beta arrays ... won't work for kpts > 0
-    rho_a, occ_alpha = get_density(basis, Calpha[0], nalpha, nmo_alpha, kid)
-    rho_b, occ_beta = get_density(basis, Cbeta[0], nbeta, nmo_beta, kid)
+    rho_alpha, occ_alpha = get_density(basis, Calpha[0], nalpha, nmo_alpha, kid)
+    rho_beta, occ_beta = get_density(basis, Cbeta[0], nbeta, nmo_beta, kid)
 
     # kinetic energy
     T = []

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -644,6 +644,7 @@ def get_one_electron_energy(basis, C, N, kid, v_ne = None):
     # oei = T + V 
     oei = np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128')
 
+    # jellium
     if v_ne is not None:
         oei += get_matrix_elements(basis, kid, v_ne)
 
@@ -785,19 +786,23 @@ def uks(cell, basis,
 
     # jellium
     #v_ne *= 0.0
-    #nalpha = 6
-    #nbeta = 6
+    #nalpha = 8 #48
+    #nbeta = 8 #48
+    #enuc = 0.0
+
 
     # damp fock matrix (helps with convergence sometimes)
     damping_factor = 1.0
     if damp_fock :
-        damping_factor = 0.5
+        damping_factor = 0.90
 
     # diis 
     diis_dimension = 8
     diis_start_cycle = damping_iterations
 
+    rs = (3 * basis.omega / ( 4.0 * np.pi * (nalpha + nbeta)))**(1.0/3.0)
     print("")
+    print('    Wigner-Seitz radius (rs)                     %20.12f' % (rs))
     print('    exchange functional:                         %20s' % ( functional_name_dict[xc][0] ) )
     print('    correlation functional:                      %20s' % ( functional_name_dict[xc][1] ) )
     print('    e_convergence:                               %20.2e' % ( e_convergence ) )
@@ -819,6 +824,7 @@ def uks(cell, basis,
     print("    ==> Begin UKS Iterations <==")
     print("")
 
+    #print("    %5s %20s %20s %20s %10s %20s %20s %20s %20s" % ('iter', 'energy', '|dE|', '||[F, D]||', 'Nelec', '||Ca - Cb||', 'kinetic', 'coulomb', 'exchange'))
     print("    %5s %20s %20s %20s %10s" % ('iter', 'energy', '|dE|', '||[F, D]||', 'Nelec'))
 
     old_total_energy = 0.0
@@ -838,22 +844,23 @@ def uks(cell, basis,
 
     # nmo ... number of desired molecular orbitals ... must be at least ne
     # warning: ace has trouble for nmo > ne with eigsh, but lobpcg seems to work
-    nmo = nalpha + 1
+    nmo = nalpha
     if nbeta > nalpha:  
-        nmo = nbeta  + 1
+        nmo = nbeta
 
     for kid in range ( len(basis.kpts) ):
 
-        #Calpha.append(np.random.rand(basis.n_plane_waves_per_k[kid], nmo) * 1e-8)
-        #Cbeta.append(np.random.rand(basis.n_plane_waves_per_k[kid], nmo) * 1e-8)
-        Calpha.append(np.zeros((basis.n_plane_waves_per_k[kid], nmo), dtype='complex128'))
-        Cbeta.append(np.zeros((basis.n_plane_waves_per_k[kid], nmo), dtype='complex128'))
+        Calpha.append(np.random.rand(basis.n_plane_waves_per_k[kid], nmo) * 1e-3)
+        Cbeta.append(np.random.rand(basis.n_plane_waves_per_k[kid], nmo) * 1e-3)
+        #Calpha.append(np.zeros((basis.n_plane_waves_per_k[kid], nmo), dtype='complex128'))
+        #Cbeta.append(np.zeros((basis.n_plane_waves_per_k[kid], nmo), dtype='complex128'))
         for i in range (nmo):
             Calpha[kid][i, i] = 1.0
         for i in range (nmo):
             Cbeta[kid][i, i] = 1.0
         Calpha[kid] = orthonormalize(Calpha[kid])
-        Cbeta[kid] = orthonormalize(Cbeta[kid])
+        #Cbeta[kid] = orthonormalize(Cbeta[kid])
+        Cbeta[kid] = Calpha[kid].copy()
 
 
         Binv_alpha_ace.append(np.zeros((nmo, nmo), dtype='complex128'))
@@ -910,6 +917,13 @@ def uks(cell, basis,
         kgtmp = basis.kpts[kid] + basis.g[basis.kg_to_g[kid, :basis.n_plane_waves_per_k[kid]]]
         T.append(np.einsum('ij,ij->i', kgtmp, kgtmp) / 2.0)
 
+        #epsilon_alpha, Calpha[kid] = scipy.linalg.eigh(np.diag(T[kid]), eigvals=(0, nmo-1))
+        #Calpha[kid] = orthonormalize(Calpha[kid])
+        #Cbeta[kid] = Calpha[kid].copy()
+
+    #print(2*np.sum(np.sort(T[0])[:nalpha]))
+    #exit()
+
     v_alpha = 0 * v_ne
     v_beta = 0 * v_ne
     v_alpha_old = 0 * v_ne
@@ -919,6 +933,32 @@ def uks(cell, basis,
     rho_beta = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
     rho_alpha_old = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
     rho_beta_old = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
+
+    # jellium guess
+    rho_alpha = nalpha / basis.omega * np.ones(basis.real_space_grid_dim, dtype = 'float64')
+    rho_beta = nbeta / basis.omega * np.ones(basis.real_space_grid_dim, dtype = 'float64')
+
+    # rebuild potentials
+    rho = rho_alpha + rho_beta
+
+    # coulomb potential
+    tmp = np.fft.ifftn(rho)
+    for myg in range( len(basis.g) ):
+        inner_rhog[myg] = tmp[ get_miller_indices(myg, basis) ]
+
+    v_coulomb = 4.0 * np.pi * np.divide(inner_rhog, basis.g2, out = np.zeros_like(basis.g2), where = basis.g2 != 0.0)
+
+    # jellium
+    #v_coulomb *= 0.0
+
+    # exchange-correlation potential
+    if xc != 'hf' :
+
+        v_xc_alpha, v_xc_beta = get_xc_potential(xc, basis, rho_alpha, rho_beta, libxc_x_functional, libxc_c_functional)
+        xc_energy = get_xc_energy(xc, basis, rho_alpha, rho_beta, libxc_x_functional, libxc_c_functional)
+
+    v_alpha = v_coulomb + v_xc_alpha
+    v_beta = v_coulomb + v_xc_beta
 
     for scf_iter in range(maxiter):
 
@@ -934,11 +974,11 @@ def uks(cell, basis,
         # potential in real space
         v_alpha_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
         v_alpha_r.ravel()[flat_idx] = v_alpha + v_ne
-        v_alpha_r = np.fft.fftn(v_alpha_r)
+        v_alpha_r = np.fft.fftn(v_alpha_r).real
 
         v_beta_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
         v_beta_r.ravel()[flat_idx] = v_beta + v_ne
-        v_beta_r = np.fft.fftn(v_beta_r)
+        v_beta_r = np.fft.fftn(v_beta_r).real
 
         # zero density for this iteration
         rho = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
@@ -1129,20 +1169,17 @@ def uks(cell, basis,
             rho_alpha = (1.0-damp) * rho_alpha + damp * rho_alpha_old
             rho_beta = (1.0-damp) * rho_beta + damp * rho_beta_old
 
-        else :
 
-            #v_coulomb = inner_diis.update(v_coulomb, error_vector)
+        solution_vector = np.hstack( (rho_alpha.flatten(), rho_beta.flatten()) )
+        #solution_vector = np.hstack( (v_alpha, v_beta) )
+        new_solution_vector = inner_diis.update(solution_vector, error_vector)
+        #v_alpha = new_solution_vector[:len(v_alpha)]
+        #v_beta = new_solution_vector[len(v_alpha):]
+        rho_alpha = new_solution_vector[:len(solution_vector)//2].reshape(rho_alpha_old.shape)
+        rho_beta = new_solution_vector[len(solution_vector)//2:].reshape(rho_beta_old.shape)
 
-            solution_vector = np.hstack( (rho_alpha.flatten(), rho_beta.flatten()) )
-            #solution_vector = np.hstack( (v_alpha, v_beta) )
-            new_solution_vector = inner_diis.update(solution_vector, error_vector)
-            #v_alpha = new_solution_vector[:len(v_alpha)]
-            #v_beta = new_solution_vector[len(v_alpha):]
-            rho_alpha = new_solution_vector[:len(solution_vector)//2].reshape(rho_alpha_old.shape)
-            rho_beta = new_solution_vector[len(solution_vector)//2:].reshape(rho_beta_old.shape)
-
-            rho_alpha.clip(min = 0)
-            rho_beta.clip(min = 0)
+        rho_alpha.clip(min = 0)
+        rho_beta.clip(min = 0)
 
         # rebuild potentials
         rho = rho_alpha + rho_beta
@@ -1153,6 +1190,9 @@ def uks(cell, basis,
             inner_rhog[myg] = tmp[ get_miller_indices(myg, basis) ]
 
         v_coulomb = 4.0 * np.pi * np.divide(inner_rhog, basis.g2, out = np.zeros_like(basis.g2), where = basis.g2 != 0.0)
+
+        # jellium
+        #v_coulomb *= 0.0
 
         # exchange-correlation potential
         if xc != 'hf' :
@@ -1187,6 +1227,9 @@ def uks(cell, basis,
             Vnl = Vnl + Vnl.conj().T
             diag = np.diag(Vnl)
             np.fill_diagonal(Vnl, 0.5 * diag)
+
+            # jellium
+            #Vnl *= 0.0
 
             def apply_fock_operator_to_orbital(c):
                 """
@@ -1273,21 +1316,22 @@ def uks(cell, basis,
             my_v_r = v_alpha_r.copy()
             my_Ki = Ki_alpha[kid].copy()
             my_Binv = Binv_alpha_ace[kid].copy()
-            epsilon_alpha[kid], Calpha[kid] = scipy.sparse.linalg.lobpcg(F_C, Calpha[kid], largest=False, maxiter=2000, tol=d_convergence*0.1)
+            epsilon_alpha[kid], Calpha[kid] = scipy.sparse.linalg.lobpcg(F_C, Calpha[kid], largest=False, maxiter=200, tol=d_convergence*0.1)
 
             my_N = nbeta
             occ_list = occ_beta.copy()
             my_v_r = v_beta_r.copy()
             my_Ki = Ki_beta[kid].copy()
             my_Binv = Binv_beta_ace[kid].copy()
-            epsilon_beta[kid], Cbeta[kid] = scipy.sparse.linalg.lobpcg(F_C, Cbeta[kid], largest=False, maxiter=2000, tol=d_convergence*0.1)
+            epsilon_beta[kid], Cbeta[kid] = scipy.sparse.linalg.lobpcg(F_C, Cbeta[kid], largest=False, maxiter=200, tol=d_convergence*0.1)
 
-            #epsilon_alpha[kid], Calpha[kid] = scipy.linalg.eigh(fock_a[kid], eigvals=(0, nalpha))
+            #epsilon_alpha[kid], Calpha[kid] = scipy.linalg.eigh(np.diag(T[kid]), eigvals=(0, nalpha))
             #epsilon_beta[kid], Cbeta[kid] = scipy.linalg.eigh(fock_b[kid], eigvals=(0, nbeta))
 
             # why do i need to orthonormalize my orbitals???
             Calpha[kid] = orthonormalize(Calpha[kid])
             Cbeta[kid] = orthonormalize(Cbeta[kid])
+            #Cbeta[kid] = Calpha[kid].copy()
 
             # break spin symmetry? # TODO this is broken, which probably indicates there is some other problem ...
             #if guess_mix is True and scf_iter == 0:
@@ -1338,6 +1382,9 @@ def uks(cell, basis,
 
         v_coulomb = 4.0 * np.pi * np.divide(inner_rhog, basis.g2, out = np.zeros_like(basis.g2), where = basis.g2 != 0.0)
 
+        # jellium
+        #v_coulomb *= 0.0
+
         # exchange-correlation potential
         if xc != 'hf' :
 
@@ -1351,6 +1398,7 @@ def uks(cell, basis,
             if nbeta > 0:
                 my_xc_energy = get_exact_exchange_energy(basis, occ_beta, nbeta, Cbeta)
                 xc_energy += my_xc_energy
+            # jellium
             xc_energy -= 0.5 * (nalpha + nbeta) * madelung
 
         # total energy
@@ -1365,7 +1413,8 @@ def uks(cell, basis,
         # charge
         charge = ( basis.omega / ( basis.real_space_grid_dim[0] * basis.real_space_grid_dim[1] * basis.real_space_grid_dim[2] ) ) * np.sum(np.absolute(rho))
 
-        print("    %5i %20.12lf %20.12lf %20.12lf %10.6lf" %  ( scf_iter, new_total_energy, energy_diff, conv, charge ) )
+        #print("    %5i %20.12lf %20.12lf %20.12lf %10.6lf %20.12f %20.12f %20.12f %20.12f %20.12f" %  ( scf_iter, new_total_energy, energy_diff, conv, charge, np.linalg.norm(Calpha[kid] - Cbeta[kid]), np.real(one_electron_energy), np.real(coulomb_energy), np.real(xc_energy), -0.5 * (nalpha + nbeta) * madelung))
+        print("    %5i %20.12lf %20.12lf %20.12lf %10.6lf" %  ( scf_iter, new_total_energy, energy_diff, conv, charge))
 
         if conv < d_convergence and energy_diff < e_convergence :
             break

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -638,6 +638,7 @@ def get_one_electron_energy(basis, C, N, kid, v_ne = None, jellium = False):
 
     return one_electron_energy
 
+# TODO: don't store any npw x npw objects
 def get_coulomb_energy(basis, C, N, kid, v_coulomb):
     """
 
@@ -1166,8 +1167,8 @@ def uks(cell, basis,
             Fa_c += Vnl @ Calpha[kid][:, :nmo_alpha]
             Fb_c += Vnl @ Cbeta[kid][:, :nmo_beta]
 
-            #grad_a = Fa_c - epsilon_alpha[kid][np.newaxis, :nalpha] * Calpha[kid][:,:nalpha]
-            #grad_b = Fb_c - epsilon_beta[kid][np.newaxis, :nbeta] * Cbeta[kid][:,:nbeta]
+            #grad_a = Fa_c - epsilon_alpha[kid][np.newaxis, :nmo_alpha] * Calpha[kid][:,:nmo_alpha]
+            #grad_b = Fb_c - epsilon_beta[kid][np.newaxis, :nmo_beta] * Cbeta[kid][:,:nmo_beta]
 
             c_Fa_c = Calpha[kid][:, :nmo_alpha].conj().T @ Fa_c
             c_Fb_c = Cbeta[kid][:, :nmo_beta].conj().T @ Fb_c
@@ -1233,8 +1234,18 @@ def uks(cell, basis,
                 epsilon_beta[kid], Cbeta[kid] = scipy.sparse.linalg.lobpcg(Fb_C, Cbeta[kid], largest=False, maxiter=2000, tol=d_convergence*0.1)
 
             else :
-                epsilon_alpha[kid], Calpha[kid] = scipy.linalg.eigh(np.diag(T[kid]), eigvals=(0, nalpha))
+                #epsilon_alpha[kid], Calpha[kid] = scipy.linalg.eigh(np.diag(T[kid]), eigvals=(0, nalpha))
                 #epsilon_beta[kid], Cbeta[kid] = scipy.linalg.eigh(fock_b[kid], eigvals=(0, nbeta))
+
+                eps_a, ca = np.linalg.eigh(np.diag(T[kid]))
+                epsilon_alpha[kid], Calpha[kid] = eps_a[:nalpha], ca[:, :nalpha]
+
+                #lowest_energy_T_index = np.argsort(T[kid])[:nalpha]
+                ##test = T[kid][lowest_energy_T_index]
+                #epsilon_alpha[kid] = T[kid][lowest_energy_T_index]
+                #Calpha[kid] = np.zeros((len(T[kid]), nalpha), dtype=np.complex128)
+                #for orb_idx, pw_idx in enumerate(lowest_energy_T_index):
+                #    Calpha[kid][pw_idx, orb_idx] = 1.
 
             # break spin symmetry? # TODO this is broken, which probably indicates there is some other problem ...
             #if guess_mix is True and scf_iter == 0:

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -977,6 +977,7 @@ def uks(cell, basis,
     B_alpha_ace = []
     B_beta_ace = []
 
+    # for ace
     Ki_alpha = []
     Ki_beta = []
 
@@ -1095,8 +1096,6 @@ def uks(cell, basis,
         conv = np.linalg.norm(error_vector)
 
         # damp or extrapolate density or potential
-        rho_alpha_old = rho_alpha.copy()
-        rho_beta_old = rho_beta.copy()
         if scf_iter < diis_start_cycle:
 
             # damping?
@@ -1105,6 +1104,7 @@ def uks(cell, basis,
 
         solution_vector = np.hstack( (rho_alpha.flatten(), rho_beta.flatten()) )
         new_solution_vector = diis.update(solution_vector, error_vector)
+
         rho_alpha = new_solution_vector[:len(solution_vector)//2].reshape(rho_alpha_old.shape)
         rho_beta = new_solution_vector[len(solution_vector)//2:].reshape(rho_beta_old.shape)
 
@@ -1280,6 +1280,10 @@ def uks(cell, basis,
 
             # coulomb part of the energy: 1/2 J
             coulomb_energy += get_coulomb_energy(basis, Cbeta[kid], nbeta, kid, v_coulomb)
+
+        # save old density
+        rho_alpha_old = rho_alpha.copy()
+        rho_beta_old = rho_beta.copy()
 
         # exchange-correlation energy
         if xc != 'hf' :

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -48,7 +48,64 @@ def orthonormalize(C):
     # apply to orbitals
     return C @ S_inv_sqrt
 
-def get_exact_exchange_energy(basis, occupied_orbitals, N, C, exchange_matrix, compute_exchange_matrix = False):
+def get_exact_exchange_energy(basis, occupied_orbitals, N, C):
+    """
+
+    evaluate the exact Hartree-Fock exchange energy, according to
+
+        Ex = - 2 pi / Omega sum_{mn in occ} sum_{g} |Cmn(g)|^2 / |g|^2
+
+    where
+
+        Cmn(g) = FT[ phi_m(r) phi_n*(r) ]
+
+    see JCP 108, 4697 (1998) for more details.
+
+    :param basis: plane wave basis information
+    :param occupied_orbitals: a list of occupied orbitals
+    :param N: the number of electrons
+    :param N: the MO transformation matrix
+
+    :return exchange_energy: the exact Hartree-Fock exchange energy
+
+    """
+
+    # precompute indices
+
+    # FFT grid shape
+    grid_shape = basis.real_space_grid_dim  # e.g., (nx, ny, nz)
+    
+    # Precompute: for each compact G index `myg`, find its flat index in FFT grid ordering
+    flat_idx = np.empty(len(basis.g), dtype=np.int64)
+    for myg in range(len(basis.g)):
+        ix, iy, iz = get_miller_indices(myg, basis)
+        flat_idx[myg] = np.ravel_multi_index((ix, iy, iz), grid_shape)
+
+    # precompute FFT[1/|r-r'|/g2]
+    inv_g2 = np.zeros_like(basis.g2)
+    mask = basis.g2 != 0.0
+    inv_g2[mask] = 1.0 / basis.g2[mask]
+
+    # accumulate exchange energy and matrix
+    exchange_energy = 0.0
+
+    for i in range(0, N):
+        for j in range(0, N):
+
+            # Cij(r') = phi_i(r') phi_j*(r')
+            # Cij(g) = FFT[Cij(r')]
+            tmp = np.fft.ifftn(occupied_orbitals[j].conj() * occupied_orbitals[i])
+            Cij = tmp.ravel()[flat_idx]
+
+            # Kij(g) = Cij(g) * FFT[1/|r-r'|]
+            Kij = Cij * inv_g2
+
+            exchange_energy += np.sum( Cij.conj() * Kij )
+
+    return -2.0 * np.pi / basis.omega * exchange_energy
+
+
+def get_exact_exchange_potential(basis, occupied_orbitals, N, C):
     """
 
     evaluate the exact Hartree-Fock exchange energy, according to
@@ -103,10 +160,8 @@ def get_exact_exchange_energy(basis, occupied_orbitals, N, C, exchange_matrix, c
 
             exchange_energy += np.sum( Cij.conj() * Kij )
 
-    if not compute_exchange_matrix :
-        return -2.0 * np.pi / basis.omega * exchange_energy, exchange_matrix
-
     # build exchange matrix in planewave basis
+    exchange_matrix = np.zeros((basis.n_plane_waves_per_k[0], basis.n_plane_waves_per_k[0]), dtype='complex128')
 
     Kij_G = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
 
@@ -148,40 +203,6 @@ def get_exact_exchange_energy(basis, occupied_orbitals, N, C, exchange_matrix, c
             kk = basis.kg_to_g[0][k]
             
             exchange_matrix[k, i] = row_g[ get_miller_indices(kk, basis) ] 
-
-    # build exchange matrix in occupied orbital basis, then transform to planewave basis
-
-    #Ki_G = np.zeros(basis.n_plane_waves_per_k[0], dtype = 'complex128')
-    #for i in range(0, N):
-
-    #    # Ki(r) = sum_j Kij(r) phi_j(r)
-    #    Ki_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
-
-    #    for j in range(0, N):
-
-    #        # Cij(r') = phi_i(r') phi_j*(r')
-    #        # Cij(g) = FFT[Cij(r')]
-    #        tmp = np.fft.ifftn(occupied_orbitals[j].conj() * occupied_orbitals[i])
-    #        Cij = tmp.ravel()[flat_idx]
-
-    #        # Kij(g) = Cij(g) * FFT[1/|r-r'|]
-    #        Kij_G.ravel()[flat_idx] = Cij * inv_g2 #Kij
-
-    #        # Kij(r) = FFT^-1[Kij(g)]
-    #        Kij_r = np.fft.fftn(Kij_G)
-
-    #        # action of K on an occupied orbital, i: 
-    #        # Ki(r) = sum_j Kij(r) phi_j(r)
-    #        Ki_r += Kij_r * occupied_orbitals[j]
-
-    #    # Ki(G) 
-    #    Ki_G_big = np.fft.ifftn(Ki_r).ravel()[flat_idx]
-    #    for i_orb in range( basis.n_plane_waves_per_k[0] ):
-    #        i_dens = basis.kg_to_g[0][i_orb]
-    #        Ki_G[i_orb] = Ki_G_big[i_dens]
-
-    #    # accumulate exchange matrix
-    #    exchange_matrix += np.outer(Ki_G, C[0][:, i].conj())
 
     return -2.0 * np.pi / basis.omega * exchange_energy, -4.0 * np.pi / basis.omega * exchange_matrix
 
@@ -352,7 +373,7 @@ def get_xc_potential(xc, basis, rho_alpha, rho_beta, libxc_x_functional, libxc_c
     else :
 
         # TODO: fix for general k
-        xc_energy, v_xc = get_exact_exchange_energy(basis, occupied_orbitals, N, C)
+        xc_energy = get_exact_exchange_energy(basis, occupied_orbitals, N, C)
 
     return v_xc_alpha, v_xc_beta
 
@@ -589,42 +610,6 @@ def form_fock_matrix(basis, kid, v = None):
         fock += get_matrix_elements(basis, kid, v)
     
     # get non-local part of the pseudopotential (not jellium)
-    #if basis.use_pseudopotential:
-    #    fock += get_nonlocal_pseudopotential_matrix_elements(basis, kid, use_legendre = basis.nl_pp_use_legendre)
-
-    # get kinetic energy
-    kgtmp = basis.kpts[kid] + basis.g[basis.kg_to_g[kid, :basis.n_plane_waves_per_k[kid]]]
-    T = np.einsum('ij,ij->i', kgtmp, kgtmp) / 2.0 
-    diagonals = T + fock.diagonal()
-    np.fill_diagonal(fock, diagonals)
-
-    # only upper triangle of fock is populated ... symmetrize and rescale diagonal
-    fock = fock + fock.conj().T
-    diag = np.diag(fock)
-    np.fill_diagonal(fock, 0.5 * diag)
-
-    return fock
-
-def form_part_of_fock_matrix(basis, kid, v = None): 
-    """
-
-    form fock matrix
-
-    :param basis: plane wave basis information
-    :param kid: index for a given k-point
-    :param v: the potential ( coulomb + xc + electron-nucleus / local pp )
-
-    :return fock: the fock matrix
-
-    """
-
-    fock = np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128')
-
-    # unpack potential
-    if v is not None:
-        fock += get_matrix_elements(basis, kid, v)
-    
-    # get non-local part of the pseudopotential
     if basis.use_pseudopotential:
         fock += get_nonlocal_pseudopotential_matrix_elements(basis, kid, use_legendre = basis.nl_pp_use_legendre)
 
@@ -640,7 +625,6 @@ def form_part_of_fock_matrix(basis, kid, v = None):
     np.fill_diagonal(fock, 0.5 * diag)
 
     return fock
-
 
 def get_one_electron_energy(basis, C, N, kid, v_ne = None):
     """
@@ -774,9 +758,6 @@ def uks(cell, basis,
     v_coulomb = np.zeros(len(basis.g), dtype = 'complex128')
     v_xc_alpha = np.zeros(len(basis.g), dtype = 'complex128')
     v_xc_beta = np.zeros(len(basis.g), dtype = 'complex128')
-
-    exchange_matrix_alpha = np.zeros((basis.n_plane_waves_per_k[0], basis.n_plane_waves_per_k[0]), dtype='complex128')
-    exchange_matrix_beta = np.zeros((basis.n_plane_waves_per_k[0], basis.n_plane_waves_per_k[0]), dtype='complex128')
 
     # density in reciprocal space
     rhog = np.zeros(len(basis.g), dtype = 'complex128')
@@ -1226,12 +1207,6 @@ def uks(cell, basis,
                 #F_c = T[kid] * c + tmp + Vnl @ c # eigsh
                 F_c = T[kid][:, None] * c + tmp + Vnl @ c # lobpcg
 
-                #print('v_r * occ', tmp.shape)
-                #print('Vnl * c  ', (Vnl @ c).shape)
-                #print('T * c    ', (T[kid][:, None] * c).shape)
-                #print('c        ', c.shape)
-                #print('F c      ', F_c.shape)
-
                 # ace
 
                 # (< phi_j | K) | c >
@@ -1265,14 +1240,14 @@ def uks(cell, basis,
             my_v_r = v_alpha_r.copy()
             my_Ki = Ki_alpha[kid].copy()
             my_Binv = Binv_alpha_ace[kid].copy()
-            epsilon_alpha[kid], Calpha[kid] = scipy.sparse.linalg.lobpcg(F_C, Calpha[kid], largest=False, maxiter=200, tol=d_convergence*0.1)
+            epsilon_alpha[kid], Calpha[kid] = scipy.sparse.linalg.lobpcg(F_C, Calpha[kid], largest=False, maxiter=2000, tol=d_convergence*0.1)
 
             my_N = nbeta
             occ_list = occ_beta.copy()
             my_v_r = v_beta_r.copy()
             my_Ki = Ki_beta[kid].copy()
             my_Binv = Binv_beta_ace[kid].copy()
-            epsilon_beta[kid], Cbeta[kid] = scipy.sparse.linalg.lobpcg(F_C, Cbeta[kid], largest=False, maxiter=200, tol=d_convergence*0.1)
+            epsilon_beta[kid], Cbeta[kid] = scipy.sparse.linalg.lobpcg(F_C, Cbeta[kid], largest=False, maxiter=2000, tol=d_convergence*0.1)
 
             #epsilon_alpha[kid], Calpha[kid] = scipy.linalg.eigh(fock_a[kid], eigvals=(0, nalpha))
             #epsilon_beta[kid], Cbeta[kid] = scipy.linalg.eigh(fock_b[kid], eigvals=(0, nbeta))
@@ -1338,10 +1313,10 @@ def uks(cell, basis,
 
         else :
 
-            # we'll deal with hf exchange matrices on the fly ... here, just get the energy
-            xc_energy, exchange_matrix_alpha = get_exact_exchange_energy(basis, occ_alpha, nalpha, Calpha, exchange_matrix_alpha, False)
+            # exact exchange energy
+            xc_energy = get_exact_exchange_energy(basis, occ_alpha, nalpha, Calpha)
             if nbeta > 0:
-                my_xc_energy, exchange_matrix_beta = get_exact_exchange_energy(basis, occ_beta, nbeta, Cbeta, exchange_matrix_beta, False)
+                my_xc_energy = get_exact_exchange_energy(basis, occ_beta, nbeta, Cbeta)
                 xc_energy += my_xc_energy
             xc_energy -= 0.5 * (nalpha + nbeta) * madelung
 

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -70,22 +70,6 @@ def get_exact_exchange_energy(basis, occupied_orbitals, N, C):
 
     """
 
-    # precompute indices
-
-    # FFT grid shape
-    grid_shape = basis.real_space_grid_dim  # e.g., (nx, ny, nz)
-    
-    # Precompute: for each compact G index `myg`, find its flat index in FFT grid ordering
-    flat_idx = np.empty(len(basis.g), dtype=np.int64)
-    for myg in range(len(basis.g)):
-        ix, iy, iz = get_miller_indices(myg, basis)
-        flat_idx[myg] = np.ravel_multi_index((ix, iy, iz), grid_shape)
-
-    # precompute FFT[1/|r-r'|/g2]
-    inv_g2 = np.zeros_like(basis.g2)
-    mask = basis.g2 != 0.0
-    inv_g2[mask] = 1.0 / basis.g2[mask]
-
     # accumulate exchange energy and matrix
     exchange_energy = 0.0
 
@@ -95,10 +79,10 @@ def get_exact_exchange_energy(basis, occupied_orbitals, N, C):
             # Cij(r') = phi_i(r') phi_j*(r')
             # Cij(g) = FFT[Cij(r')]
             tmp = np.fft.ifftn(occupied_orbitals[j].conj() * occupied_orbitals[i])
-            Cij = tmp.ravel()[flat_idx]
+            Cij = tmp.ravel()[basis.flat_idx]
 
             # Kij(g) = Cij(g) * FFT[1/|r-r'|]
-            Kij = Cij * inv_g2
+            Kij = Cij * basis.inv_g2
 
             exchange_energy += np.sum( Cij.conj() * Kij )
 
@@ -128,22 +112,6 @@ def get_exact_exchange_potential(basis, occupied_orbitals, N, C):
 
     """
 
-    # precompute indices
-
-    # FFT grid shape
-    grid_shape = basis.real_space_grid_dim  # e.g., (nx, ny, nz)
-    
-    # Precompute: for each compact G index `myg`, find its flat index in FFT grid ordering
-    flat_idx = np.empty(len(basis.g), dtype=np.int64)
-    for myg in range(len(basis.g)):
-        ix, iy, iz = get_miller_indices(myg, basis)
-        flat_idx[myg] = np.ravel_multi_index((ix, iy, iz), grid_shape)
-
-    # precompute FFT[1/|r-r'|/g2]
-    inv_g2 = np.zeros_like(basis.g2)
-    mask = basis.g2 != 0.0
-    inv_g2[mask] = 1.0 / basis.g2[mask]
-
     # accumulate exchange energy and matrix
     exchange_energy = 0.0
 
@@ -153,10 +121,10 @@ def get_exact_exchange_potential(basis, occupied_orbitals, N, C):
             # Cij(r') = phi_i(r') phi_j*(r')
             # Cij(g) = FFT[Cij(r')]
             tmp = np.fft.ifftn(occupied_orbitals[j].conj() * occupied_orbitals[i])
-            Cij = tmp.ravel()[flat_idx]
+            Cij = tmp.ravel()[basis.flat_idx]
 
             # Kij(g) = Cij(g) * FFT[1/|r-r'|]
-            Kij = Cij * inv_g2
+            Kij = Cij * basis.inv_g2
 
             exchange_energy += np.sum( Cij.conj() * Kij )
 
@@ -177,7 +145,7 @@ def get_exact_exchange_potential(basis, occupied_orbitals, N, C):
         tmp = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
         #for myg in range( len(basis.g) ):
         #    tmp[ get_miller_indices(myg, basis) ] = phi_i[myg]
-        tmp.ravel()[flat_idx] = phi_i
+        tmp.ravel()[basis.flat_idx] = phi_i
         phi_i = np.fft.fftn(tmp)
 
         for j in range(0, N):
@@ -185,10 +153,10 @@ def get_exact_exchange_potential(basis, occupied_orbitals, N, C):
             # Cij(r') = phi_i(r') phi_j*(r')
             # Cij(g) = FFT[Cij(r')]
             tmp = np.fft.ifftn(occupied_orbitals[j].conj() * phi_i)
-            Cij = tmp.ravel()[flat_idx]
+            Cij = tmp.ravel()[basis.flat_idx]
 
             # Kij(g) = Cij(g) * FFT[1/|r-r'|]
-            Kij_G.ravel()[flat_idx] = Cij * inv_g2 #Kij
+            Kij_G.ravel()[basis.flat_idx] = Cij * basis.inv_g2 #Kij
 
             # Kij(r) = FFT^-1[Kij(g)]
             Kij_r = np.fft.fftn(Kij_G)
@@ -896,29 +864,6 @@ def uks(cell, basis,
     coulomb_energy = 0.0
     recompute_exchange = True
 
-    # precompute indices
-
-    # FFT grid shape
-    grid_shape = basis.real_space_grid_dim  # e.g., (nx, ny, nz)
-    
-    # for each compact G index `myg`, find its flat index in FFT grid ordering
-    flat_idx = np.empty(len(basis.g), dtype=np.int64)
-    for myg in range(len(basis.g)):
-        ix, iy, iz = get_miller_indices(myg, basis)
-        flat_idx[myg] = np.ravel_multi_index((ix, iy, iz), grid_shape)
-
-    # precompute linear grid indices for each k-point
-    grid_idx_k = []
-    for kid in range ( len(basis.kpts) ):
-        ijk = np.array([get_miller_indices(ik, basis) for ik in basis.kg_to_g[kid]])
-        coords = tuple(ijk.T)
-        grid_idx_k.append(np.ravel_multi_index(coords, grid_shape))
-
-    # precompute FFT[1/|r-r'|/g2]
-    inv_g2 = np.zeros_like(basis.g2)
-    mask = basis.g2 != 0.0
-    inv_g2[mask] = 1.0 / basis.g2[mask]
-
     # so we have occ_alpha and occ_beta arrays ... won't work for kpts > 0
     my_rho_a, occ_alpha = get_density(basis, Calpha[0], nalpha, nmo_alpha, kid)
     my_rho_b, occ_beta = get_density(basis, Cbeta[0], nbeta, nmo_beta, kid)
@@ -986,11 +931,11 @@ def uks(cell, basis,
 
         # potential in real space
         v_alpha_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
-        v_alpha_r.ravel()[flat_idx] = v_alpha + v_ne
+        v_alpha_r.ravel()[basis.flat_idx] = v_alpha + v_ne
         v_alpha_r = np.fft.fftn(v_alpha_r).real
 
         v_beta_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
-        v_beta_r.ravel()[flat_idx] = v_beta + v_ne
+        v_beta_r.ravel()[basis.flat_idx] = v_beta + v_ne
         v_beta_r = np.fft.fftn(v_beta_r).real
 
         # zero density for this iteration
@@ -1008,6 +953,7 @@ def uks(cell, basis,
 
         for kid in range( len(basis.kpts) ):
 
+            # TODO: don't store non-local pseudopotential in the planewave basis
             Vnl = get_nonlocal_pseudopotential_matrix_elements(basis, kid, use_legendre = basis.nl_pp_use_legendre)
             Vnl = Vnl + Vnl.conj().T
             diag = np.diag(Vnl)
@@ -1029,10 +975,10 @@ def uks(cell, basis,
                         # Cij(r') = phi_i(r') phi_j*(r')
                         # Cij(g) = FFT[Cij(r')]
                         tmp = np.fft.ifftn(occ_alpha[j].conj() * occ_alpha[i])
-                        Cij = tmp.ravel()[flat_idx]
+                        Cij = tmp.ravel()[basis.flat_idx]
 
                         # Kij(g) = Cij(g) * FFT[1/|r-r'|]
-                        Kij_G.ravel()[flat_idx] = Cij * inv_g2 #Kij
+                        Kij_G.ravel()[basis.flat_idx] = Cij * basis.inv_g2 #Kij
 
                         # Kij(r) = FFT^-1[Kij(g)]
                         Kij_r = np.fft.fftn(Kij_G)
@@ -1046,20 +992,20 @@ def uks(cell, basis,
                 # action of potential on orbitals in real space, then transform to reciprocal space
                 tmp = v_alpha_r * occ_alpha[i] #+ Ki_r # real space, 3d
                 tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
-                tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
+                tmp = tmp.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
 
                 Fa_c[:,i] = T[kid] * Calpha[kid][:, i] + tmp[basis.kg_to_g[kid]] # map last term to small flattened basis
 
                 # for ace
                 tmp = Ki_r # real space, 3d
                 tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
-                tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
+                tmp = tmp.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
                 Ki_alpha[kid][:,i] = tmp[basis.kg_to_g[kid]] # reciprocal space, small flattened basis
 
                 # non-ace exchange
                 tmp = Ki_r # real space, 3d
                 tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
-                tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
+                tmp = tmp.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
                 exchange_alpha[:,i] = tmp[basis.kg_to_g[kid]] # map last term to small flattened basis
 
             Fb_c = np.zeros((basis.n_plane_waves_per_k[kid], nmo_beta), dtype='complex128')
@@ -1074,10 +1020,10 @@ def uks(cell, basis,
                         # Cij(r') = phi_i(r') phi_j*(r')
                         # Cij(g) = FFT[Cij(r')]
                         tmp = np.fft.ifftn(occ_beta[j].conj() * occ_beta[i])
-                        Cij = tmp.ravel()[flat_idx]
+                        Cij = tmp.ravel()[basis.flat_idx]
 
                         # Kij(g) = Cij(g) * FFT[1/|r-r'|]
-                        Kij_G.ravel()[flat_idx] = Cij * inv_g2 #Kij
+                        Kij_G.ravel()[basis.flat_idx] = Cij * basis.inv_g2 #Kij
 
                         # Kij(r) = FFT^-1[Kij(g)]
                         Kij_r = np.fft.fftn(Kij_G)
@@ -1091,19 +1037,19 @@ def uks(cell, basis,
                 # action of potential on orbitals in real space, then transform to reciprocal space
                 tmp = v_beta_r * occ_beta[i] #+ Ki_r  # real space, 3d
                 tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
-                tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
+                tmp = tmp.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
                 Fb_c[:,i] = T[kid] * Cbeta[kid][:, i] + tmp[basis.kg_to_g[kid]] # map last term to small flattened basis
 
                 # for ace
                 tmp = Ki_r  # real space, 3d
                 tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
-                tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
+                tmp = tmp.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
                 Ki_beta[kid][:,i] = tmp[basis.kg_to_g[kid]] # reciprocal space, small flattened basis
 
                 # non-ace exchange
                 tmp = Ki_r # real space, 3d
                 tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
-                tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
+                tmp = tmp.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
                 exchange_beta[:,i] = tmp[basis.kg_to_g[kid]] # map last term to small flattened basis
 
             if xc == 'hf':
@@ -1220,11 +1166,11 @@ def uks(cell, basis,
     
         # potential in real space
         v_alpha_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
-        v_alpha_r.ravel()[flat_idx] = v_alpha + v_ne
+        v_alpha_r.ravel()[basis.flat_idx] = v_alpha + v_ne
         v_alpha_r = np.fft.fftn(v_alpha_r).real
 
         v_beta_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
-        v_beta_r.ravel()[flat_idx] = v_beta + v_ne
+        v_beta_r.ravel()[basis.flat_idx] = v_beta + v_ne
         v_beta_r = np.fft.fftn(v_beta_r).real
 
         one_electron_energy = 0.0
@@ -1262,9 +1208,9 @@ def uks(cell, basis,
 
                 # orbital in real space
                 #occ = np.zeros(np.prod(grid_shape), dtype=np.complex128) # eigsh
-                occ = np.zeros([np.prod(grid_shape), c.shape[1]], dtype=np.complex128) # lobpcg
-                occ[grid_idx_k[kid]] = c
-                occ = occ.reshape(grid_shape)
+                occ = np.zeros([np.prod(basis.real_space_grid_dim), c.shape[1]], dtype=np.complex128) # lobpcg
+                occ[basis.grid_idx_k[kid]] = c
+                occ = occ.reshape(basis.real_space_grid_dim)
                 occ = np.fft.fftn(occ) 
 
                 # exchange
@@ -1275,10 +1221,10 @@ def uks(cell, basis,
                         # Cij(r') = phi_i(r') phi_j*(r')
                         # Cij(g) = FFT[Cij(r')]
                         tmp = np.fft.ifftn(occ_list[j].conj() * occ)
-                        Cij = tmp.ravel()[flat_idx]
+                        Cij = tmp.ravel()[basis.flat_idx]
 
                         # Kij(g) = Cij(g) * FFT[1/|r-r'|]
-                        Kij_G.ravel()[flat_idx] = Cij * inv_g2 #Kij
+                        Kij_G.ravel()[basis.flat_idx] = Cij * basis.inv_g2 #Kij
 
                         # Kij(r) = FFT^-1[Kij(g)]
                         Kij_r = np.fft.fftn(Kij_G)
@@ -1292,7 +1238,7 @@ def uks(cell, basis,
                 # action of potential on orbitals in real space, then transform to reciprocal space
                 tmp = my_v_r * occ  # real space, 3d
                 tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
-                tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
+                tmp = tmp.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
                 tmp = tmp[basis.kg_to_g[kid]] # reciprocal space, small flattened basis
                 tmp = tmp.reshape(c.shape) # for lobpcg
 
@@ -1315,7 +1261,7 @@ def uks(cell, basis,
                 if not ace_exchange :
                     tmp = Ki_r # real space, 3d
                     tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
-                    tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
+                    tmp = tmp.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
                     tmp = tmp[basis.kg_to_g[kid]] # reciprocal space, small flattened basis
                     tmp = tmp.reshape(c.shape) # for lobpcg
 

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -468,7 +468,7 @@ def get_nonlocal_pp_energy(basis, C, N, kid, occupation_numbers):
 
     return nonlocal_pp_energy
 
-def fock_on_orbitals(basis, kid, ne, nmo, phi_r, C, T, v_r, Vnl, xc, occupation_numbers):
+def fock_on_orbitals(basis, kid, ne, nmo, phi_r, C, T, v_r, Vnl, xc, occupation_numbers, adiabatic_exchange_lambda):
     """
     evaluate action of fock matrix on orbitals and build ace operator
 
@@ -483,6 +483,7 @@ def fock_on_orbitals(basis, kid, ne, nmo, phi_r, C, T, v_r, Vnl, xc, occupation_
     :param Vnl: matrix representation of non-local pseudopotential, in reciprocal space
     :param xc: the exchange-correlation functional
     :param occupation_numbers: a list of occupation numbers (0, 1, or fermi-dirac for smearing)
+    :param adiabatic_exchange_lambda: a scaling factor on the interval [0, 1] for ramping up exchange
 
 
     :return F_c: the action of the fock matrix on the orbials
@@ -537,7 +538,7 @@ def fock_on_orbitals(basis, kid, ne, nmo, phi_r, C, T, v_r, Vnl, xc, occupation_
         tmp = tmp.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
         exchange[:,i] = tmp[basis.kg_to_g[kid]] # map last term to small flattened basis
 
-    return F_c, Ki, exchange
+    return F_c, Ki, exchange * adiabatic_exchange_lambda
 
 def fock_on_orbitals_using_ace(basis, kid, ne, nmo, phi_r, c, T, v_r, Vnl, xc, Ki, B_ace, ace_exchange, occupation_numbers, adiabatic_exchange_lambda):
     """
@@ -626,7 +627,7 @@ def fock_on_orbitals_using_ace(basis, kid, ne, nmo, phi_r, c, T, v_r, Vnl, xc, K
 
     return F_c
 
-def build_B_ace(ne, nmo, C, Ki, exchange):
+def build_B_ace(ne, nmo, C, Ki, exchange, adiabatic_exchange_lambda):
     """
     build B matrix for ACE
     see text after Eq. 13 of J. Chem. Theory Comput. 12, 2242-2249 (2016).
@@ -636,6 +637,7 @@ def build_B_ace(ne, nmo, C, Ki, exchange):
     :param C: orbital coefficients in reciprocal space
     :param Ki: action of exchange operator on orbitals in reciprocal space
     :param exchange: exchange contribution to fock matrix (exact, for testing ace)
+    :param adiabatic_exchange_lambda: a scaling factor on the interval [0, 1] for ramping up exchange
 
     :return B_ace: the B matrix for ACE
     """
@@ -660,7 +662,7 @@ def build_B_ace(ne, nmo, C, Ki, exchange):
     # sum_j B_{ij} < phi_j | K | c > 
     tmp = B_ace @ tmp 
     # sum_i K | phi_i >  B_{ij} < phi_j | K | c >
-    ace = Ki @ tmp 
+    ace = Ki @ tmp * adiabatic_exchange_lambda
 
     assert (np.allclose(ace, exchange))
 
@@ -1031,7 +1033,7 @@ def uks(cell, basis,
         if jellium:
             eps_a, ca = np.linalg.eigh(np.diag(T[kid]))
             epsilon_alpha[kid], Calpha[kid] = eps_a[:nmo_alpha], ca[:, :nmo_alpha]
-            Calpha[kid] += np.random.rand(basis.n_plane_waves_per_k[kid], nmo_alpha) * 1e-4
+            Calpha[kid] += np.random.rand(basis.n_plane_waves_per_k[kid], nmo_alpha) * 1e-6
             Calpha[kid] = orthonormalize(Calpha[kid])
             Cbeta[kid] = Calpha[kid].copy()
             #one_electron_energy = np.sum(np.einsum('pi,p->i', np.abs(Calpha[kid][:,:nalpha])**2, T[kid]))
@@ -1084,16 +1086,16 @@ def uks(cell, basis,
             if jellium:
                 Vnl *= 0.0
 
-            Fa_c, Ki_alpha[kid], exchange_alpha = fock_on_orbitals(basis, kid, nalpha, nmo_alpha, phi_alpha, Calpha, T, v_alpha_r, Vnl, xc, occ_num_alpha)
-            Fb_c, Ki_beta[kid], exchange_beta = fock_on_orbitals(basis, kid, nbeta, nmo_beta, phi_beta, Cbeta, T, v_beta_r, Vnl, xc, occ_num_beta)
+            Fa_c, Ki_alpha[kid], exchange_alpha = fock_on_orbitals(basis, kid, nalpha, nmo_alpha, phi_alpha, Calpha, T, v_alpha_r, Vnl, xc, occ_num_alpha, adiabatic_exchange_lambda)
+            Fb_c, Ki_beta[kid], exchange_beta = fock_on_orbitals(basis, kid, nbeta, nmo_beta, phi_beta, Cbeta, T, v_beta_r, Vnl, xc, occ_num_beta, adiabatic_exchange_lambda)
 
             if xc == 'hf':
 
-                B_alpha_ace[kid] = build_B_ace(nalpha, nmo_alpha, Calpha[kid], Ki_alpha[kid], exchange_alpha)
-                B_beta_ace[kid] = build_B_ace(nbeta, nmo_beta, Cbeta[kid], Ki_beta[kid], exchange_beta)
+                B_alpha_ace[kid] = build_B_ace(nalpha, nmo_alpha, Calpha[kid], Ki_alpha[kid], exchange_alpha, adiabatic_exchange_lambda)
+                B_beta_ace[kid] = build_B_ace(nbeta, nmo_beta, Cbeta[kid], Ki_beta[kid], exchange_beta, adiabatic_exchange_lambda)
 
-                Fa_c += exchange_alpha * adiabatic_exchange_lambda
-                Fb_c += exchange_beta * adiabatic_exchange_lambda
+                Fa_c += exchange_alpha
+                Fb_c += exchange_beta
             
             Fa_c += Vnl @ Calpha[kid][:, :nmo_alpha]
             Fb_c += Vnl @ Cbeta[kid][:, :nmo_beta]
@@ -1287,10 +1289,10 @@ def uks(cell, basis,
         else :
             print("    %5i %20.12lf %20.12lf %20.12lf %10.6lf" %  ( scf_iter, new_total_energy, energy_diff, conv, charge))
 
-        #if scf_iter < 1000:
-        #    adiabatic_exchange_lambda += 0.001
+       # if scf_iter < 9:
+       #     adiabatic_exchange_lambda += 0.1
 
-        if conv < d_convergence and energy_diff < e_convergence: # and scf_iter >= 1000:
+        if conv < d_convergence and energy_diff < e_convergence: # and scf_iter >= 10:
             break
 
     if scf_iter == maxiter - 1:

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -610,7 +610,7 @@ def form_fock_matrix(basis, kid, v = None):
         fock += get_matrix_elements(basis, kid, v)
     
     # get non-local part of the pseudopotential (not jellium)
-    if basis.use_pseudopotential:
+    if basis.use_pseudopotential and not jellium:
         fock += get_nonlocal_pseudopotential_matrix_elements(basis, kid, use_legendre = basis.nl_pp_use_legendre)
 
     # get kinetic energy
@@ -626,7 +626,7 @@ def form_fock_matrix(basis, kid, v = None):
 
     return fock
 
-def get_one_electron_energy(basis, C, N, kid, v_ne = None):
+def get_one_electron_energy(basis, C, N, kid, v_ne = None, jellium = False):
     """
 
     get one-electron part of the energy
@@ -645,11 +645,12 @@ def get_one_electron_energy(basis, C, N, kid, v_ne = None):
     oei = np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128')
 
     # jellium
-    if v_ne is not None:
-        oei += get_matrix_elements(basis, kid, v_ne)
+    if not jellium:
+        if v_ne is not None:
+            oei += get_matrix_elements(basis, kid, v_ne)
 
-    if basis.use_pseudopotential:
-        oei += get_nonlocal_pseudopotential_matrix_elements(basis, kid, use_legendre = basis.nl_pp_use_legendre)
+        if basis.use_pseudopotential:
+            oei += get_nonlocal_pseudopotential_matrix_elements(basis, kid, use_legendre = basis.nl_pp_use_legendre)
 
     kgtmp = basis.kpts[kid] + basis.g[basis.kg_to_g[kid, :basis.n_plane_waves_per_k[kid]]]
     T = np.einsum('ij,ij->i', kgtmp, kgtmp) / 2.0 
@@ -711,6 +712,8 @@ def uks(cell, basis,
         damp_fock = True, 
         damping_iterations = 4,
         ace_exchange = True,
+        jellium = False,
+        jellium_ne = 2,
         maxiter=500):
 
     """
@@ -785,11 +788,11 @@ def uks(cell, basis,
     total_charge = cell.charge
 
     # jellium
-    #v_ne *= 0.0
-    #nalpha = 8 #48
-    #nbeta = 8 #48
-    #enuc = 0.0
-
+    if jellium:
+        v_ne *= 0.0
+        nalpha = jellium_ne // 2
+        nbeta = jellium_ne // 2
+        enuc = 0.0
 
     # damp fock matrix (helps with convergence sometimes)
     damping_factor = 1.0
@@ -824,8 +827,10 @@ def uks(cell, basis,
     print("    ==> Begin UKS Iterations <==")
     print("")
 
-    #print("    %5s %20s %20s %20s %10s %20s %20s %20s %20s" % ('iter', 'energy', '|dE|', '||[F, D]||', 'Nelec', '||Ca - Cb||', 'kinetic', 'coulomb', 'exchange'))
-    print("    %5s %20s %20s %20s %10s" % ('iter', 'energy', '|dE|', '||[F, D]||', 'Nelec'))
+    if jellium:
+        print("    %5s %20s %20s %20s %10s %20s %20s %20s %20s %20s" % ('iter', 'energy', '|dE|', '||[F, D]||', 'Nelec', '||Ca - Cb||', 'kinetic', 'coulomb', 'exchange', 'madelung'))
+    else :
+        print("    %5s %20s %20s %20s %10s" % ('iter', 'energy', '|dE|', '||[F, D]||', 'Nelec'))
 
     old_total_energy = 0.0
 
@@ -948,8 +953,9 @@ def uks(cell, basis,
 
     v_coulomb = 4.0 * np.pi * np.divide(inner_rhog, basis.g2, out = np.zeros_like(basis.g2), where = basis.g2 != 0.0)
 
-    # jellium
-    #v_coulomb *= 0.0
+    # jellium ... but only true in the thermodynamic limit
+    if jellium:
+        v_coulomb *= 0.0
 
     # exchange-correlation potential
     if xc != 'hf' :
@@ -1001,7 +1007,8 @@ def uks(cell, basis,
             np.fill_diagonal(Vnl, 0.5 * diag)
 
             # jellium
-            #Vnl *= 0.0
+            if jellium:
+                Vnl *= 0.0
 
             Fa_c = np.zeros((basis.n_plane_waves_per_k[kid], nmo), dtype='complex128')
             exchange_alpha = np.zeros((basis.n_plane_waves_per_k[kid], nmo), dtype='complex128')
@@ -1191,8 +1198,9 @@ def uks(cell, basis,
 
         v_coulomb = 4.0 * np.pi * np.divide(inner_rhog, basis.g2, out = np.zeros_like(basis.g2), where = basis.g2 != 0.0)
 
-        # jellium
-        #v_coulomb *= 0.0
+        # jellium ... but only true in the thermodynamic limit
+        if jellium:
+            v_coulomb *= 0.0
 
         # exchange-correlation potential
         if xc != 'hf' :
@@ -1229,7 +1237,8 @@ def uks(cell, basis,
             np.fill_diagonal(Vnl, 0.5 * diag)
 
             # jellium
-            #Vnl *= 0.0
+            if jellium:
+                Vnl *= 0.0
 
             def apply_fock_operator_to_orbital(c):
                 """
@@ -1311,27 +1320,30 @@ def uks(cell, basis,
 
             F_C = LinearOperator((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), matvec=apply_fock_operator_to_orbital, dtype='complex128')
 
-            my_N = nalpha
-            occ_list = occ_alpha.copy()
-            my_v_r = v_alpha_r.copy()
-            my_Ki = Ki_alpha[kid].copy()
-            my_Binv = Binv_alpha_ace[kid].copy()
-            epsilon_alpha[kid], Calpha[kid] = scipy.sparse.linalg.lobpcg(F_C, Calpha[kid], largest=False, maxiter=200, tol=d_convergence*0.1)
+            if not jellium:
+                my_N = nalpha
+                occ_list = occ_alpha.copy()
+                my_v_r = v_alpha_r.copy()
+                my_Ki = Ki_alpha[kid].copy()
+                my_Binv = Binv_alpha_ace[kid].copy()
+                epsilon_alpha[kid], Calpha[kid] = scipy.sparse.linalg.lobpcg(F_C, Calpha[kid], largest=False, maxiter=2000, tol=d_convergence*0.1)
 
-            my_N = nbeta
-            occ_list = occ_beta.copy()
-            my_v_r = v_beta_r.copy()
-            my_Ki = Ki_beta[kid].copy()
-            my_Binv = Binv_beta_ace[kid].copy()
-            epsilon_beta[kid], Cbeta[kid] = scipy.sparse.linalg.lobpcg(F_C, Cbeta[kid], largest=False, maxiter=200, tol=d_convergence*0.1)
+                my_N = nbeta
+                occ_list = occ_beta.copy()
+                my_v_r = v_beta_r.copy()
+                my_Ki = Ki_beta[kid].copy()
+                my_Binv = Binv_beta_ace[kid].copy()
+                epsilon_beta[kid], Cbeta[kid] = scipy.sparse.linalg.lobpcg(F_C, Cbeta[kid], largest=False, maxiter=2000, tol=d_convergence*0.1)
 
-            #epsilon_alpha[kid], Calpha[kid] = scipy.linalg.eigh(np.diag(T[kid]), eigvals=(0, nalpha))
-            #epsilon_beta[kid], Cbeta[kid] = scipy.linalg.eigh(fock_b[kid], eigvals=(0, nbeta))
+            else :
+                epsilon_alpha[kid], Calpha[kid] = scipy.linalg.eigh(np.diag(T[kid]), eigvals=(0, nalpha))
+                #epsilon_beta[kid], Cbeta[kid] = scipy.linalg.eigh(fock_b[kid], eigvals=(0, nbeta))
 
             # why do i need to orthonormalize my orbitals???
             Calpha[kid] = orthonormalize(Calpha[kid])
             Cbeta[kid] = orthonormalize(Cbeta[kid])
-            #Cbeta[kid] = Calpha[kid].copy()
+            if jellium:
+                Cbeta[kid] = Calpha[kid].copy()
 
             # break spin symmetry? # TODO this is broken, which probably indicates there is some other problem ...
             #if guess_mix is True and scf_iter == 0:
@@ -1358,14 +1370,16 @@ def uks(cell, basis,
                                                            Calpha[kid], 
                                                            nalpha, 
                                                            kid, 
-                                                           v_ne = v_ne)
+                                                           v_ne = v_ne,
+                                                           jellium = jellium)
 
             # one-electron part of the energy (beta)
             one_electron_energy += get_one_electron_energy(basis, 
                                                            Cbeta[kid], 
                                                            nbeta, 
                                                            kid, 
-                                                           v_ne = v_ne)
+                                                           v_ne = v_ne,
+                                                           jellium = jellium)
 
             # coulomb part of the energy: 1/2 J
             coulomb_energy += get_coulomb_energy(basis, Calpha[kid], nalpha, kid, v_coulomb)
@@ -1382,8 +1396,9 @@ def uks(cell, basis,
 
         v_coulomb = 4.0 * np.pi * np.divide(inner_rhog, basis.g2, out = np.zeros_like(basis.g2), where = basis.g2 != 0.0)
 
-        # jellium
-        #v_coulomb *= 0.0
+        # jellium ... but only true in the thermodynamic limit
+        if jellium:
+            v_coulomb *= 0.0
 
         # exchange-correlation potential
         if xc != 'hf' :
@@ -1398,11 +1413,15 @@ def uks(cell, basis,
             if nbeta > 0:
                 my_xc_energy = get_exact_exchange_energy(basis, occ_beta, nbeta, Cbeta)
                 xc_energy += my_xc_energy
+
             # jellium
-            xc_energy -= 0.5 * (nalpha + nbeta) * madelung
+            if not jellium:
+                xc_energy -= 0.5 * (nalpha + nbeta) * madelung
 
         # total energy
         new_total_energy = np.real(one_electron_energy) + np.real(coulomb_energy) + np.real(xc_energy) + enuc
+        if jellium:
+            new_total_energy -= 0.5 * (nalpha + nbeta) * madelung
 
         # convergence in energy
         energy_diff = np.abs(new_total_energy - old_total_energy)
@@ -1413,8 +1432,10 @@ def uks(cell, basis,
         # charge
         charge = ( basis.omega / ( basis.real_space_grid_dim[0] * basis.real_space_grid_dim[1] * basis.real_space_grid_dim[2] ) ) * np.sum(np.absolute(rho))
 
-        #print("    %5i %20.12lf %20.12lf %20.12lf %10.6lf %20.12f %20.12f %20.12f %20.12f %20.12f" %  ( scf_iter, new_total_energy, energy_diff, conv, charge, np.linalg.norm(Calpha[kid] - Cbeta[kid]), np.real(one_electron_energy), np.real(coulomb_energy), np.real(xc_energy), -0.5 * (nalpha + nbeta) * madelung))
-        print("    %5i %20.12lf %20.12lf %20.12lf %10.6lf" %  ( scf_iter, new_total_energy, energy_diff, conv, charge))
+        if jellium:
+            print("    %5i %20.12lf %20.12lf %20.12lf %10.6lf %20.12f %20.12f %20.12f %20.12f %20.12f" %  ( scf_iter, new_total_energy, energy_diff, conv, charge, np.linalg.norm(Calpha[kid] - Cbeta[kid]), np.real(one_electron_energy), np.real(coulomb_energy), np.real(xc_energy), -0.5 * (nalpha + nbeta) * madelung))
+        else :
+            print("    %5i %20.12lf %20.12lf %20.12lf %10.6lf" %  ( scf_iter, new_total_energy, energy_diff, conv, charge))
 
         if conv < d_convergence and energy_diff < e_convergence :
             break
@@ -1435,9 +1456,14 @@ def uks(cell, basis,
     print('    one-electron energy:      %20.12lf' % ( np.real(one_electron_energy) ) )
     print('    coulomb energy:           %20.12lf' % ( np.real(coulomb_energy) ) )
     print('    xc energy:                %20.12lf' % ( np.real(xc_energy) ) )
+    if jellium:
+        print('    Madelung:                 %20.12lf' % ( -0.5 * (nalpha + nbeta) * madelung) )
     print('')
-    print('    total energy:             %20.12lf' % ( np.real(one_electron_energy) + np.real(coulomb_energy) + np.real(xc_energy) + enuc ) )
+    if jellium:
+        print('    total energy:             %20.12lf' % ( np.real(one_electron_energy) + np.real(coulomb_energy) + np.real(xc_energy) + enuc -0.5 * (nalpha + nbeta) * madelung ) )
+    else :
+        print('    total energy:             %20.12lf' % ( np.real(one_electron_energy) + np.real(coulomb_energy) + np.real(xc_energy) + enuc ) )
     print('')
 
-    return np.real(one_electron_energy) + np.real(coulomb_energy) + np.real(xc_energy) + enuc, Calpha, Cbeta
+    return new_total_energy, Calpha, Cbeta
 

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -508,6 +508,7 @@ def fock_on_orbitals(basis, kid, ne, nmo, phi_r, C, T, v_r, Vnl, xc, occupation_
                 Cij = tmp.ravel()[basis.flat_idx]
 
                 # Kij(g) = Cij(g) * FFT[1/|r-r'|]
+                Kij_G[:] = 0.0
                 Kij_G.ravel()[basis.flat_idx] = Cij * basis.inv_g2 #Kij
 
                 # Kij(r) = FFT^-1[Kij(g)]
@@ -520,23 +521,23 @@ def fock_on_orbitals(basis, kid, ne, nmo, phi_r, C, T, v_r, Vnl, xc, occupation_
             Ki_r *= -4.0 * np.pi / basis.omega
 
         # action of potential on orbitals in real space, then transform to reciprocal space
-        tmp = v_r * phi_r[i] #+ Ki_r # real space, 3d
-        tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
-        tmp = tmp.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
+        tmp_vphi = v_r * phi_r[i] #+ Ki_r # real space, 3d
+        tmp_vphi = np.fft.ifftn(tmp_vphi) # reciprocal space, 3d
+        tmp_vphi = tmp_vphi.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
 
-        F_c[:,i] = T[kid] * C[kid][:, i] + tmp[basis.kg_to_g[kid]] # map last term to small flattened basis
+        F_c[:,i] = T[kid] * C[kid][:, i] + tmp_vphi[basis.kg_to_g[kid]] # map last term to small flattened basis
 
         # for ace
-        tmp = Ki_r # real space, 3d
-        tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
-        tmp = tmp.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
-        Ki[:,i] = tmp[basis.kg_to_g[kid]] # reciprocal space, small flattened basis
+        tmp_Ki = Ki_r.copy() # real space, 3d
+        tmp_Ki = np.fft.ifftn(tmp_Ki) # reciprocal space, 3d
+        tmp_Ki = tmp_Ki.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
+        Ki[:,i] = tmp_Ki[basis.kg_to_g[kid]] # reciprocal space, small flattened basis
 
         # non-ace exchange
-        tmp = Ki_r # real space, 3d
-        tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
-        tmp = tmp.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
-        exchange[:,i] = tmp[basis.kg_to_g[kid]] # map last term to small flattened basis
+        tmp_exch = Ki_r.copy() # real space, 3d
+        tmp_exch = np.fft.ifftn(tmp_exch) # reciprocal space, 3d
+        tmp_exch = tmp_exch.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
+        exchange[:,i] = tmp_exch[basis.kg_to_g[kid]] # map last term to small flattened basis
 
     return F_c, Ki, exchange * adiabatic_exchange_lambda
 
@@ -581,6 +582,7 @@ def fock_on_orbitals_using_ace(basis, kid, ne, nmo, phi_r, c, T, v_r, Vnl, xc, K
             Cij = tmp.ravel()[basis.flat_idx]
 
             # Kij(g) = Cij(g) * FFT[1/|r-r'|]
+            Kij_G[:] = 0.0
             Kij_G.ravel()[basis.flat_idx] = Cij * basis.inv_g2 #Kij
 
             # Kij(r) = FFT^-1[Kij(g)]
@@ -593,14 +595,14 @@ def fock_on_orbitals_using_ace(basis, kid, ne, nmo, phi_r, c, T, v_r, Vnl, xc, K
         Ki_r *= -4.0 * np.pi / basis.omega
 
     # action of potential on orbitals in real space, then transform to reciprocal space
-    tmp = v_r * current_phi  # real space, 3d
-    tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
-    tmp = tmp.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
-    tmp = tmp[basis.kg_to_g[kid]] # reciprocal space, small flattened basis
-    tmp = tmp.reshape(c.shape) # for lobpcg
+    tmp_vphi = v_r * current_phi  # real space, 3d
+    tmp_vphi = np.fft.ifftn(tmp_vphi) # reciprocal space, 3d
+    tmp_vphi = tmp_vphi.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
+    tmp_vphi = tmp_vphi[basis.kg_to_g[kid]] # reciprocal space, small flattened basis
+    tmp_vphi = tmp_vphi.reshape(c.shape) # for lobpcg
 
     #F_c = T[kid] * c + tmp + Vnl @ c # eigsh
-    F_c = T[kid][:, None] * c + tmp + Vnl @ c # lobpcg
+    F_c = T[kid][:, None] * c + tmp_vphi + Vnl @ c # lobpcg
 
     if xc == 'hf':
         if ace_exchange :
@@ -616,12 +618,12 @@ def fock_on_orbitals_using_ace(basis, kid, ne, nmo, phi_r, c, T, v_r, Vnl, xc, K
  
         else :
 
-            tmp = Ki_r # real space, 3d
-            tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
-            tmp = tmp.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
-            tmp = tmp[basis.kg_to_g[kid]] # reciprocal space, small flattened basis
-            tmp = tmp.reshape(c.shape) # for lobpcg
-            F_c += tmp * adiabatic_exchange_lambda
+            tmp_exch = Ki_r # real space, 3d
+            tmp_exch = np.fft.ifftn(tmp_exch) # reciprocal space, 3d
+            tmp_exch = tmp_exch.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
+            tmp_exch = tmp_exch[basis.kg_to_g[kid]] # reciprocal space, small flattened basis
+            tmp_exch = tmp_exch.reshape(c.shape) # for lobpcg
+            F_c += tmp_exch * adiabatic_exchange_lambda
 
     #print(np.linalg.norm(ace - tmp))
 
@@ -712,18 +714,14 @@ def compute_local_potentials(rho_alpha, rho_beta, v_ne, basis, xc, libxc_x_funct
         v_beta +=  v_xc_beta
 
     # alpha-spin potential in real space
-    v_alpha_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
-    v_alpha_r.ravel()[basis.flat_idx] = v_alpha + v_ne
-    v_alpha_r = np.fft.fftn(v_alpha_r).real
+    v_alpha_G = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
+    v_alpha_G.ravel()[basis.flat_idx] = v_alpha + v_ne
+    v_alpha_r = np.fft.fftn(v_alpha_G).real
 
     # beta-spin potential in real space
-    v_beta_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
-    v_beta_r.ravel()[basis.flat_idx] = v_beta + v_ne
-    v_beta_r = np.fft.fftn(v_beta_r).real
-
-    #if jellium:
-    #    v_alpha_r -= v_alpha_r.mean()
-    #    v_beta_r -= v_beta_r.mean()
+    v_beta_G = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
+    v_beta_G.ravel()[basis.flat_idx] = v_beta + v_ne
+    v_beta_r = np.fft.fftn(v_beta_G).real
 
     return v_coulomb, v_alpha_r, v_beta_r
 
@@ -797,17 +795,17 @@ def kerker_preconditioning(rho_alpha, rho_beta, rho_alpha_old, rho_beta_old, bas
     """
 
     # 1. densities in reciprocal space
-    tmp = np.fft.ifftn(rho_alpha)
-    rho_alpha_G_new = tmp.ravel()[basis.flat_idx]
+    tmp_alpha = np.fft.ifftn(rho_alpha)
+    rho_alpha_G_new = tmp_alpha.ravel()[basis.flat_idx]
 
-    tmp = np.fft.ifftn(rho_alpha_old)
-    rho_alpha_G_old = tmp.ravel()[basis.flat_idx]
+    tmp_alpha = np.fft.ifftn(rho_alpha_old)
+    rho_alpha_G_old = tmp_alpha.ravel()[basis.flat_idx]
 
-    tmp = np.fft.ifftn(rho_beta)
-    rho_beta_G_new = tmp.ravel()[basis.flat_idx]
+    tmp_beta = np.fft.ifftn(rho_beta)
+    rho_beta_G_new = tmp_beta.ravel()[basis.flat_idx]
 
-    tmp = np.fft.ifftn(rho_beta_old)
-    rho_beta_G_old = tmp.ravel()[basis.flat_idx]
+    tmp_beta = np.fft.ifftn(rho_beta_old)
+    rho_beta_G_old = tmp_beta.ravel()[basis.flat_idx]
 
     # 2. residual in reciprocal space
     res_alpha_G = rho_alpha_G_new - rho_alpha_G_old
@@ -827,12 +825,12 @@ def kerker_preconditioning(rho_alpha, rho_beta, rho_alpha_old, rho_beta_old, bas
     rho_beta_G_new = rho_beta_G_old + alpha * res_beta_G_pre
 
     # 5. new density in real space wtf
-    tmp.ravel()[basis.flat_idx] = rho_alpha_G_new
-    rho_alpha = np.fft.fftn(tmp).real
+    tmp_alpha.ravel()[basis.flat_idx] = rho_alpha_G_new
+    rho_alpha = np.fft.fftn(tmp_alpha).real
     rho_alpha.clip(min = 0)
 
-    tmp.ravel()[basis.flat_idx] = rho_beta_G_new
-    rho_beta = np.fft.fftn(tmp).real
+    tmp_beta.ravel()[basis.flat_idx] = rho_beta_G_new
+    rho_beta = np.fft.fftn(tmp_beta).real
     rho_beta.clip(min = 0)
 
     return rho_alpha, rho_beta
@@ -920,7 +918,8 @@ def uks(cell, basis,
     # madelung correction
     madelung = tools.pbc.madelung(cell, basis.kpts)
 
-    nalpha, nbeta = cell.nelec
+    #nalpha, nbeta = cell.nelec
+    nbeta, nalpha = cell.nelec
     total_charge = cell.charge
 
     # jellium
@@ -931,8 +930,10 @@ def uks(cell, basis,
         enuc = 0.0
 
     # nmo ... number of desired molecular orbitals ... must be at least ne
-    nmo_alpha = nalpha  #+ 1
-    nmo_beta = nbeta #+ 1
+    nmo_alpha = nalpha #+ 1
+    nmo_beta = nbeta #nbeta #+ 1
+    #if guess_mix:
+    #    nmo_alpha += 1
     
     # increase nmo if we're doing smearing
     if kBT is not None:
@@ -1032,8 +1033,13 @@ def uks(cell, basis,
         # jellium orbital guess, plus some noise
         if jellium:
             eps_a, ca = np.linalg.eigh(np.diag(T[kid]))
+
             epsilon_alpha[kid], Calpha[kid] = eps_a[:nmo_alpha], ca[:, :nmo_alpha]
-            Calpha[kid] += np.random.rand(basis.n_plane_waves_per_k[kid], nmo_alpha) * 1e-6
+            # mix in other plane waves? 
+            #for j in range (0, nmo_alpha):
+            #    Calpha[kid][:, j] += 1e-5 * ca[:, nmo_alpha + j] 
+
+            Calpha[kid] += np.random.rand(basis.n_plane_waves_per_k[kid], nmo_alpha) * 1e-5
             Calpha[kid] = orthonormalize(Calpha[kid])
             Cbeta[kid] = Calpha[kid].copy()
             #one_electron_energy = np.sum(np.einsum('pi,p->i', np.abs(Calpha[kid][:,:nalpha])**2, T[kid]))
@@ -1043,9 +1049,6 @@ def uks(cell, basis,
     rho_alpha, phi_alpha = get_density(basis, Calpha[0], nalpha, nmo_alpha, kid, occ_num_alpha)
     rho_beta, phi_beta = get_density(basis, Cbeta[0], nbeta, nmo_beta, kid, occ_num_beta)
 
-    # jellium guess
-    rho_alpha = nalpha / basis.omega * np.ones(basis.real_space_grid_dim, dtype = 'float64')
-    rho_beta = nbeta / basis.omega * np.ones(basis.real_space_grid_dim, dtype = 'float64')
     rho_alpha_old = rho_alpha.copy()
     rho_beta_old = rho_beta.copy()
 
@@ -1057,252 +1060,233 @@ def uks(cell, basis,
     diis = lib.diis.DIIS()
     diis.space = diis_dimension
 
-    # begin UKS iterations
-    xc_energy = 0.0
-    scf_iter = 0 # initialize variable incase maxiter = 0
-    one_electron_energy = 0.0
-    coulomb_energy = 0.0
+    adiabatic_exchange_lambda = 0.0
+    for i in range (0, 1):
+        adiabatic_exchange_lambda += 1
 
-    adiabatic_exchange_lambda = 1.0
-    for scf_iter in range(maxiter):
-
+        # begin UKS iterations
+        xc_energy = 0.0
+        scf_iter = 0 # initialize variable incase maxiter = 0
         one_electron_energy = 0.0
         coulomb_energy = 0.0
 
-        # compute local potentials
-        v_coulomb, v_alpha_r, v_beta_r = compute_local_potentials(rho_alpha, rho_beta, v_ne, basis, xc, libxc_x_functional, libxc_c_functional, jellium)
+        for scf_iter in range(maxiter):
 
-        # evaluate the orbital gradient
-        error_vector = np.zeros(0)
-        for kid in range( len(basis.kpts) ):
+            one_electron_energy = 0.0
+            coulomb_energy = 0.0
 
-            # TODO: don't store non-local pseudopotential in the planewave basis
-            Vnl = get_nonlocal_pseudopotential_matrix_elements(basis, kid, use_legendre = basis.nl_pp_use_legendre)
-            Vnl = Vnl + Vnl.conj().T
-            diag = np.diag(Vnl)
-            np.fill_diagonal(Vnl, 0.5 * diag)
+            # compute local potentials
+            v_coulomb, v_alpha_r, v_beta_r = compute_local_potentials(rho_alpha, rho_beta, v_ne, basis, xc, libxc_x_functional, libxc_c_functional, jellium)
 
-            # jellium
-            if jellium:
-                Vnl *= 0.0
+            # evaluate the orbital gradient
+            error_vector = np.zeros(0)
+            for kid in range( len(basis.kpts) ):
 
-            Fa_c, Ki_alpha[kid], exchange_alpha = fock_on_orbitals(basis, kid, nalpha, nmo_alpha, phi_alpha, Calpha, T, v_alpha_r, Vnl, xc, occ_num_alpha, adiabatic_exchange_lambda)
-            Fb_c, Ki_beta[kid], exchange_beta = fock_on_orbitals(basis, kid, nbeta, nmo_beta, phi_beta, Cbeta, T, v_beta_r, Vnl, xc, occ_num_beta, adiabatic_exchange_lambda)
+                # TODO: don't store non-local pseudopotential in the planewave basis
+                Vnl = get_nonlocal_pseudopotential_matrix_elements(basis, kid, use_legendre = basis.nl_pp_use_legendre)
+                Vnl = Vnl + Vnl.conj().T
+                diag = np.diag(Vnl)
+                np.fill_diagonal(Vnl, 0.5 * diag)
 
-            if xc == 'hf':
+                # jellium
+                if jellium:
+                    Vnl *= 0.0
 
-                B_alpha_ace[kid] = build_B_ace(nalpha, nmo_alpha, Calpha[kid], Ki_alpha[kid], exchange_alpha, adiabatic_exchange_lambda)
-                B_beta_ace[kid] = build_B_ace(nbeta, nmo_beta, Cbeta[kid], Ki_beta[kid], exchange_beta, adiabatic_exchange_lambda)
+                Fa_c, Ki_alpha[kid], exchange_alpha = fock_on_orbitals(basis, kid, nalpha, nmo_alpha, phi_alpha, Calpha, T, v_alpha_r, Vnl, xc, occ_num_alpha, adiabatic_exchange_lambda)
+                Fb_c, Ki_beta[kid], exchange_beta = fock_on_orbitals(basis, kid, nbeta, nmo_beta, phi_beta, Cbeta, T, v_beta_r, Vnl, xc, occ_num_beta, adiabatic_exchange_lambda)
 
-                Fa_c += exchange_alpha
-                Fb_c += exchange_beta
-            
-            Fa_c += Vnl @ Calpha[kid][:, :nmo_alpha]
-            Fb_c += Vnl @ Cbeta[kid][:, :nmo_beta]
+                if xc == 'hf':
 
-            #grad_a = Fa_c - epsilon_alpha[kid][np.newaxis, :nmo_alpha] * Calpha[kid][:,:nmo_alpha]
-            #grad_b = Fb_c - epsilon_beta[kid][np.newaxis, :nmo_beta] * Cbeta[kid][:,:nmo_beta]
+                    B_alpha_ace[kid] = build_B_ace(nalpha, nmo_alpha, Calpha[kid], Ki_alpha[kid], exchange_alpha, adiabatic_exchange_lambda)
+                    B_beta_ace[kid] = build_B_ace(nbeta, nmo_beta, Cbeta[kid], Ki_beta[kid], exchange_beta, adiabatic_exchange_lambda)
 
-            c_Fa_c = Calpha[kid][:, :nmo_alpha].conj().T @ Fa_c
-            c_Fb_c = Cbeta[kid][:, :nmo_beta].conj().T @ Fb_c
-            grad_a = Fa_c - Calpha[kid][:,:nmo_alpha] @ c_Fa_c
-            grad_b = Fb_c - Cbeta[kid][:,:nmo_beta] @ c_Fb_c
+                    Fa_c += exchange_alpha
+                    Fb_c += exchange_beta
+                
+                Fa_c += Vnl @ Calpha[kid][:, :nmo_alpha]
+                Fb_c += Vnl @ Cbeta[kid][:, :nmo_beta]
 
-            error_vector = np.hstack( (error_vector, grad_a.flatten(), grad_b.flatten() ) )
+                #grad_a = Fa_c - epsilon_alpha[kid][np.newaxis, :nmo_alpha] * Calpha[kid][:,:nmo_alpha]
+                #grad_b = Fb_c - epsilon_beta[kid][np.newaxis, :nmo_beta] * Cbeta[kid][:,:nmo_beta]
 
-        # norm of the orbital gradient for convergence check
-        conv = np.linalg.norm(error_vector)
+                c_Fa_c = Calpha[kid][:, :nmo_alpha].conj().T @ Fa_c
+                c_Fb_c = Cbeta[kid][:, :nmo_beta].conj().T @ Fb_c
+                grad_a = Fa_c - Calpha[kid][:,:nmo_alpha] @ c_Fa_c
+                grad_b = Fb_c - Cbeta[kid][:,:nmo_beta] @ c_Fb_c
 
-        # kerker preconditioning
-        rho_alpha, rho_beta = kerker_preconditioning(rho_alpha, rho_beta, rho_alpha_old, rho_beta_old, basis, nalpha + nbeta, q0 = kerker_q0, alpha = kerker_alpha)
+                error_vector = np.hstack( (error_vector, grad_a.flatten(), grad_b.flatten() ) )
 
-        solution_vector = np.hstack( (rho_alpha.flatten(), rho_beta.flatten()) )
-        new_solution_vector = diis.update(solution_vector, error_vector)
+            # norm of the orbital gradient for convergence check
+            conv = np.linalg.norm(error_vector)
 
-        rho_alpha = new_solution_vector[:len(solution_vector)//2].reshape(rho_alpha_old.shape)
-        rho_beta = new_solution_vector[len(solution_vector)//2:].reshape(rho_beta_old.shape)
+            # kerker preconditioning
+            rho_alpha, rho_beta = kerker_preconditioning(rho_alpha, rho_beta, rho_alpha_old, rho_beta_old, basis, nalpha + nbeta, q0 = kerker_q0, alpha = kerker_alpha)
 
-        rho_alpha.clip(min = 0)
-        rho_beta.clip(min = 0)
+            solution_vector = np.hstack( (rho_alpha.flatten(), rho_beta.flatten()) )
+            new_solution_vector = diis.update(solution_vector, error_vector)
 
-        # recompute potentials after kerker preconditioning and diis extrapolation
-        v_coulomb, v_alpha_r, v_beta_r = compute_local_potentials(rho_alpha, rho_beta, v_ne, basis, xc, libxc_x_functional, libxc_c_functional, jellium)
+            rho_alpha = new_solution_vector[:len(solution_vector)//2].reshape(rho_alpha_old.shape)
+            rho_beta = new_solution_vector[len(solution_vector)//2:].reshape(rho_beta_old.shape)
 
-        one_electron_energy = 0.0
-        coulomb_energy = 0.0
+            rho_alpha = rho_alpha.clip(min = 0).real
+            rho_beta = rho_beta.clip(min = 0).real
 
-        rho_alpha = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
-        rho_beta = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
+            # recompute potentials after kerker preconditioning and diis extrapolation
+            v_coulomb, v_alpha_r, v_beta_r = compute_local_potentials(rho_alpha, rho_beta, v_ne, basis, xc, libxc_x_functional, libxc_c_functional, jellium)
 
-        # diagonalize fock matrix with extrapolated potential
+            one_electron_energy = 0.0
+            coulomb_energy = 0.0
 
-        for kid in range ( len(basis.kpts) ):
+            rho_alpha = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
+            rho_beta = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
 
-            Vnl = get_nonlocal_pseudopotential_matrix_elements(basis, kid, use_legendre = basis.nl_pp_use_legendre)
-            Vnl = Vnl + Vnl.conj().T
-            diag = np.diag(Vnl)
-            np.fill_diagonal(Vnl, 0.5 * diag)
+            # diagonalize fock matrix with extrapolated potential
 
-            # jellium
-            if jellium:
-                Vnl *= 0.0
+            for kid in range ( len(basis.kpts) ):
 
-            def lobpcg_alpha(c):
-                return fock_on_orbitals_using_ace(basis, kid, nalpha, nmo_alpha, phi_alpha, c, T, v_alpha_r, Vnl, xc, Ki_alpha[kid], B_alpha_ace[kid], ace_exchange, occ_num_alpha, adiabatic_exchange_lambda)
+                Vnl = get_nonlocal_pseudopotential_matrix_elements(basis, kid, use_legendre = basis.nl_pp_use_legendre)
+                Vnl = Vnl + Vnl.conj().T
+                diag = np.diag(Vnl)
+                np.fill_diagonal(Vnl, 0.5 * diag)
 
-            def lobpcg_beta(c):
-                return fock_on_orbitals_using_ace(basis, kid, nbeta, nmo_beta, phi_beta, c, T, v_beta_r, Vnl, xc, Ki_beta[kid], B_beta_ace[kid], ace_exchange, occ_num_beta, adiabatic_exchange_lambda)
+                # jellium
+                if jellium:
+                    Vnl *= 0.0
 
-            Fa_C = LinearOperator((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), matvec=lobpcg_alpha, dtype='complex128')
-            Fb_C = LinearOperator((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), matvec=lobpcg_beta, dtype='complex128')
+                def lobpcg_alpha(c):
+                    return fock_on_orbitals_using_ace(basis, kid, nalpha, nmo_alpha, phi_alpha, c, T, v_alpha_r, Vnl, xc, Ki_alpha[kid], B_alpha_ace[kid], ace_exchange, occ_num_alpha, adiabatic_exchange_lambda)
 
-            epsilon_alpha[kid], Calpha[kid] = scipy.sparse.linalg.lobpcg(Fa_C, Calpha[kid], largest=False, maxiter=200, tol=d_convergence*1e-1)
+                def lobpcg_beta(c):
+                    return fock_on_orbitals_using_ace(basis, kid, nbeta, nmo_beta, phi_beta, c, T, v_beta_r, Vnl, xc, Ki_beta[kid], B_beta_ace[kid], ace_exchange, occ_num_beta, adiabatic_exchange_lambda)
+
+                Fa_C = LinearOperator((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), matvec=lobpcg_alpha, dtype='complex128')
+                Fb_C = LinearOperator((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), matvec=lobpcg_beta, dtype='complex128')
+
+                epsilon_alpha[kid], Calpha[kid] = scipy.sparse.linalg.lobpcg(Fa_C, Calpha[kid], largest=False, maxiter=200, tol=d_convergence*1e-1)
+                if not jellium:
+                    epsilon_beta[kid], Cbeta[kid] = scipy.sparse.linalg.lobpcg(Fb_C, Cbeta[kid], largest=False, maxiter=200, tol=d_convergence*1e-1)
+                else:
+                    Cbeta[kid] = Calpha[kid].copy()
+                    epsilon_beta[kid] = epsilon_alpha[kid].copy()
+
+                # HF orbitals need to be shifted for smearing to work correctly
+                if xc == 'hf':
+                    epsilon_alpha[kid] -= madelung * occ_num_alpha
+                    epsilon_beta[kid] -= madelung * occ_num_beta
+
+                # update occupation numbers for smearing
+                mu_alpha = find_chemical_potential(nalpha, epsilon_alpha[kid], kBT = kBT)
+                mu_beta = find_chemical_potential(nbeta, epsilon_beta[kid], kBT = kBT)
+                #print('optimized mu (alpha)', mu_alpha)
+                #print('optimized mu (beta)', mu_beta)
+
+                occ_num_alpha = fermi_dirac(nalpha, epsilon_alpha[kid], mu_alpha, kBT = kBT)
+                occ_num_beta = fermi_dirac(nbeta, epsilon_beta[kid], mu_beta, kBT = kBT)
+                #print(occ_num_alpha)
+                #print('alpha', occ_num_alpha)
+                #print('beta ', occ_num_beta)
+
+                # break spin symmetry? # TODO this is broken, which probably indicates there is some other problem ...
+                #if guess_mix and scf_iter == 0:
+
+                #    c = np.cos(0.05 * np.pi)
+                #    s = np.sin(0.05 * np.pi)
+
+                #    tmp1 = c * Calpha[kid][:, nalpha-1] - s * Calpha[kid][:, nalpha]
+                #    tmp2 = s * Calpha[kid][:, nalpha-1] + c * Calpha[kid][:, nalpha]
+
+                #    Calpha[kid][:, nalpha-1] = tmp1.copy()
+                #    Calpha[kid][:, nalpha] = tmp2.copy()
+
+                # why do i need to orthonormalize my orbitals???
+                Calpha[kid] = orthonormalize(Calpha[kid])
+                Cbeta[kid] = orthonormalize(Cbeta[kid])
+                if jellium:
+                    Cbeta[kid] = Calpha[kid].copy()
+
+                # update density
+                my_rho_alpha, phi_alpha = get_density(basis, Calpha[kid], nalpha, nmo_alpha, kid, occ_num_alpha)
+                my_rho_beta, phi_beta = get_density(basis, Cbeta[kid], nbeta, nmo_beta, kid, occ_num_beta)
+
+                # density should be non-negative ...
+                rho_alpha += my_rho_alpha.clip(min = 0).real
+                rho_beta += my_rho_beta.clip(min = 0).real
+
+                # kinetic energy part of the one-electron energy
+                one_electron_energy += np.sum(np.einsum('pi,p->i', np.abs(Calpha[kid][:,:nmo_alpha])**2 * occ_num_alpha, T[kid]))
+                one_electron_energy += np.sum(np.einsum('pi,p->i', np.abs(Cbeta[kid][:,:nmo_beta])**2 * occ_num_beta, T[kid]))
+
+                # nonlocal pseudopotential part of the energy
+                if not jellium:
+                    one_electron_energy += get_nonlocal_pp_energy(basis, Calpha[kid], nmo_alpha, kid, occ_num_alpha)
+                    one_electron_energy += get_nonlocal_pp_energy(basis, Cbeta[kid], nmo_beta, kid, occ_num_beta)
+
+            # nuclear potential / local pseudopotential part of the one-electron energy
             if not jellium:
-                epsilon_beta[kid], Cbeta[kid] = scipy.sparse.linalg.lobpcg(Fb_C, Cbeta[kid], largest=False, maxiter=200, tol=d_convergence*1e-1)
-            else:
-                Cbeta[kid] = Calpha[kid].copy()
-                epsilon_beta[kid] = epsilon_alpha[kid].copy()
+                v_ne_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
+                v_ne_r.ravel()[basis.flat_idx] = v_ne
+                v_ne_r = np.fft.fftn(v_ne_r).real
+                one_electron_energy += ( basis.omega / ( basis.real_space_grid_dim[0] * basis.real_space_grid_dim[1] * basis.real_space_grid_dim[2] ) ) * np.sum((rho_alpha + rho_beta) * v_ne_r)
 
-            # HF orbitals need to be shifted for smearing to work correctly
-            if xc == 'hf':
-                epsilon_alpha[kid] -= madelung * occ_num_alpha
-                epsilon_beta[kid] -= madelung * occ_num_beta
-                #epsilon_alpha[kid][:nalpha] -= madelung
-                #epsilon_beta[kid][:nbeta] -= madelung
-                #print(epsilon_alpha[kid])
-                #print(epsilon_beta[kid])
+            # coulomb part of the energy: 1/2 J
+            v_coulomb, v_alpha_r, v_beta_r = compute_local_potentials(rho_alpha, rho_beta, v_ne, basis, xc, libxc_x_functional, libxc_c_functional, jellium)
+            v_coulomb_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
+            v_coulomb_r.ravel()[basis.flat_idx] = v_coulomb
+            v_coulomb_r = np.fft.fftn(v_coulomb_r).real
+            coulomb_energy = 0.5 * ( basis.omega / ( basis.real_space_grid_dim[0] * basis.real_space_grid_dim[1] * basis.real_space_grid_dim[2] ) ) * np.sum((rho_alpha + rho_beta) * v_coulomb_r)
 
-            #if not jellium:
+            # save old density
+            rho_alpha_old = rho_alpha.copy()
+            rho_beta_old = rho_beta.copy()
 
-            #    Fa_C = LinearOperator((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), matvec=lobpcg_alpha, dtype='complex128')
-            #    Fb_C = LinearOperator((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), matvec=lobpcg_beta, dtype='complex128')
+            # exchange-correlation energy
+            if xc != 'hf' :
+                xc_energy = get_xc_energy(xc, basis, rho_alpha, rho_beta, libxc_x_functional, libxc_c_functional)
 
-            #    epsilon_alpha[kid], Calpha[kid] = scipy.sparse.linalg.lobpcg(Fa_C, Calpha[kid], largest=False, maxiter=200, tol=d_convergence*0.01)
-            #    epsilon_beta[kid], Cbeta[kid] = scipy.sparse.linalg.lobpcg(Fb_C, Cbeta[kid], largest=False, maxiter=200, tol=d_convergence*0.01)
+            else :
 
-            #else :
+                # exact exchange energy
+                xc_energy = get_exact_exchange_energy(basis, phi_alpha, nmo_alpha, Calpha, occ_num_alpha)
+                if nbeta > 0:
+                    my_xc_energy = get_exact_exchange_energy(basis, phi_beta, nmo_beta, Cbeta, occ_num_beta)
+                    xc_energy += my_xc_energy
 
-            #    eps_a, ca = np.linalg.eigh(np.diag(T[kid]))
-            #    epsilon_alpha[kid], Calpha[kid] = eps_a[:nalpha], ca[:, :nalpha]
+                # jellium
+                if not jellium:
+                    xc_energy -= 0.5 * (nalpha + nbeta) * madelung
 
-            #eps_a, ca = np.linalg.eigh(np.diag(T[kid]))
-            #epsilon_alpha[kid], Calpha[kid] = eps_a[:nmo_alpha], ca[:, :nmo_alpha]
-            #print(epsilon_alpha[kid])
-            #exit()
-
-            # update occupation numbers for smearing
-            mu_alpha = find_chemical_potential(nalpha, epsilon_alpha[kid], kBT = kBT)
-            mu_beta = find_chemical_potential(nbeta, epsilon_beta[kid], kBT = kBT)
-            #print('optimized mu (alpha)', mu_alpha)
-            #print('optimized mu (beta)', mu_beta)
-
-            occ_num_alpha = fermi_dirac(nalpha, epsilon_alpha[kid], mu_alpha, kBT = kBT)
-            occ_num_beta = fermi_dirac(nbeta, epsilon_beta[kid], mu_beta, kBT = kBT)
-            #print(occ_num_alpha)
-            #print(occ_num_alpha)
-            #print(occ_num_beta)
-
-            # break spin symmetry? # TODO this is broken, which probably indicates there is some other problem ...
-            #if guess_mix is True and scf_iter == 0:
-
-            #    c = np.cos(0.05 * np.pi)
-            #    s = np.sin(0.05 * np.pi)
-
-            #    tmp1 = c * Calpha[kid][:, nalpha-1] - s * Calpha[kid][:, nalpha]
-            #    tmp2 = s * Calpha[kid][:, nalpha-1] + c * Calpha[kid][:, nalpha]
-
-            #    Calpha[kid][:, nalpha-1] = tmp1.copy()
-            #    Calpha[kid][:, nalpha] = tmp2.copy()
-
-            # why do i need to orthonormalize my orbitals???
-            Calpha[kid] = orthonormalize(Calpha[kid])
-            Cbeta[kid] = orthonormalize(Cbeta[kid])
+            # total energy
+            new_total_energy = np.real(one_electron_energy) + np.real(coulomb_energy) + np.real(xc_energy) + enuc
             if jellium:
-                Cbeta[kid] = Calpha[kid].copy()
+                new_total_energy -= 0.5 * (nalpha + nbeta) * madelung
 
-            # update density
-            my_rho_alpha, phi_alpha = get_density(basis, Calpha[kid], nalpha, nmo_alpha, kid, occ_num_alpha)
-            my_rho_beta, phi_beta = get_density(basis, Cbeta[kid], nbeta, nmo_beta, kid, occ_num_beta)
+            # convergence in energy
+            energy_diff = np.abs(new_total_energy - old_total_energy)
 
-            # density should be non-negative ...
-            rho_alpha += my_rho_alpha.clip(min = 0)
-            rho_beta += my_rho_beta.clip(min = 0)
+            # update energy
+            old_total_energy = new_total_energy
 
-            # kinetic energy part of the one-electron energy
-            one_electron_energy += np.sum(np.einsum('pi,p->i', np.abs(Calpha[kid][:,:nmo_alpha])**2 * occ_num_alpha, T[kid]))
-            one_electron_energy += np.sum(np.einsum('pi,p->i', np.abs(Cbeta[kid][:,:nmo_beta])**2 * occ_num_beta, T[kid]))
+            # charge
+            charge = ( basis.omega / ( basis.real_space_grid_dim[0] * basis.real_space_grid_dim[1] * basis.real_space_grid_dim[2] ) ) * np.sum(np.absolute(rho_alpha + rho_beta))
 
-            # nonlocal pseudopotential part of the energy
-            if not jellium:
-                one_electron_energy += get_nonlocal_pp_energy(basis, Calpha[kid], nmo_alpha, kid, occ_num_alpha)
-                one_electron_energy += get_nonlocal_pp_energy(basis, Cbeta[kid], nmo_beta, kid, occ_num_beta)
+            if jellium:
+                print("    %5i %20.12lf %20.12lf %20.12lf %10.6lf %20.12f %20.12f %20.12f %20.12f %20.12f" %  ( scf_iter, new_total_energy, energy_diff, conv, charge, np.linalg.norm(Calpha[kid] - Cbeta[kid]), np.real(one_electron_energy), np.real(coulomb_energy), np.real(xc_energy), -0.5 * (nalpha + nbeta) * madelung))
+            else :
+                print("    %5i %20.12lf %20.12lf %20.12lf %10.6lf" %  ( scf_iter, new_total_energy, energy_diff, conv, charge))
 
-        # nuclear potential / local pseudopotential part of the one-electron energy
-        if not jellium:
-            v_ne_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
-            v_ne_r.ravel()[basis.flat_idx] = v_ne
-            v_ne_r = np.fft.fftn(v_ne_r).real
-            one_electron_energy += ( basis.omega / ( basis.real_space_grid_dim[0] * basis.real_space_grid_dim[1] * basis.real_space_grid_dim[2] ) ) * np.sum((rho_alpha + rho_beta) * v_ne_r)
+            if conv < d_convergence and energy_diff < e_convergence:
+                break
 
-        # coulomb part of the energy: 1/2 J
-        v_coulomb_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
-        v_coulomb_r.ravel()[basis.flat_idx] = v_coulomb
-        v_coulomb_r = np.fft.fftn(v_coulomb_r).real
-        coulomb_energy = 0.5 * ( basis.omega / ( basis.real_space_grid_dim[0] * basis.real_space_grid_dim[1] * basis.real_space_grid_dim[2] ) ) * np.sum((rho_alpha + rho_beta) * v_coulomb_r)
+        if scf_iter == maxiter - 1:
+            print('')
+            print('    UKS iterations did not converge.')
+            print('')
+        else:
+            print('')
+            print('    UKS iterations converged!')
+            print('')
 
-        # save old density
-        rho_alpha_old = rho_alpha.copy()
-        rho_beta_old = rho_beta.copy()
-
-        # exchange-correlation energy
-        if xc != 'hf' :
-            xc_energy = get_xc_energy(xc, basis, rho_alpha, rho_beta, libxc_x_functional, libxc_c_functional)
-
-        else :
-
-            # exact exchange energy
-            xc_energy = get_exact_exchange_energy(basis, phi_alpha, nmo_alpha, Calpha, occ_num_alpha)
-            if nbeta > 0:
-                my_xc_energy = get_exact_exchange_energy(basis, phi_beta, nmo_beta, Cbeta, occ_num_beta)
-                xc_energy += my_xc_energy
-
-            # jellium
-            if not jellium:
-                xc_energy -= 0.5 * (nalpha + nbeta) * madelung
-
-        # total energy
-        new_total_energy = np.real(one_electron_energy) + np.real(coulomb_energy) + np.real(xc_energy) + enuc
-        if jellium:
-            new_total_energy -= 0.5 * (nalpha + nbeta) * madelung
-
-        # convergence in energy
-        energy_diff = np.abs(new_total_energy - old_total_energy)
-
-        # update energy
-        old_total_energy = new_total_energy
-
-        # charge
-        charge = ( basis.omega / ( basis.real_space_grid_dim[0] * basis.real_space_grid_dim[1] * basis.real_space_grid_dim[2] ) ) * np.sum(np.absolute(rho_alpha + rho_beta))
-
-        if jellium:
-            print("    %5i %20.12lf %20.12lf %20.12lf %10.6lf %20.12f %20.12f %20.12f %20.12f %20.12f" %  ( scf_iter, new_total_energy, energy_diff, conv, charge, np.linalg.norm(Calpha[kid] - Cbeta[kid]), np.real(one_electron_energy), np.real(coulomb_energy), np.real(xc_energy), -0.5 * (nalpha + nbeta) * madelung))
-        else :
-            print("    %5i %20.12lf %20.12lf %20.12lf %10.6lf" %  ( scf_iter, new_total_energy, energy_diff, conv, charge))
-
-       # if scf_iter < 9:
-       #     adiabatic_exchange_lambda += 0.1
-
-        if conv < d_convergence and energy_diff < e_convergence: # and scf_iter >= 10:
-            break
-
-    if scf_iter == maxiter - 1:
-        print('')
-        print('    UKS iterations did not converge.')
-        print('')
-    else:
-        print('')
-        print('    UKS iterations converged!')
-        print('')
+    # end of adiabatic increase in exchange 
 
 
     print('    ==> energy components <==')

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -1050,53 +1050,55 @@ def uks(cell, basis,
                 tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
                 exchange_beta[:,i] = tmp[basis.kg_to_g[kid]] # map last term to small flattened basis
 
-            # for ace < phi_i | Kj>^{-1}
-            tmp = -Calpha[kid][:, :nmo].conj().T @ Ki_alpha[kid]
-            L = np.linalg.cholesky(tmp)
+            if xc == 'hf':
 
-            # how's our cholesky decomposition looking?
-            assert (np.allclose(tmp, L @ L.conj().T))
+                # for ace < phi_i | Kj>^{-1}
+                tmp = -Calpha[kid][:, :nmo].conj().T @ Ki_alpha[kid]
+                L = np.linalg.cholesky(tmp)
 
-            Linv = np.linalg.inv(L)
-            Binv_alpha_ace[kid] = -Linv.conj().T @ Linv
+                # how's our cholesky decomposition looking?
+                assert (np.allclose(tmp, L @ L.conj().T))
 
-            # how's our inverse looking?
-            assert (np.allclose(-tmp @ Binv_alpha_ace[kid], np.eye(tmp.shape[0])))
+                Linv = np.linalg.inv(L)
+                Binv_alpha_ace[kid] = -Linv.conj().T @ Linv
 
-            tmp = -Cbeta[kid][:, :nmo].conj().T @ Ki_beta[kid]
-            L = np.linalg.cholesky(tmp)
+                # how's our inverse looking?
+                assert (np.allclose(-tmp @ Binv_alpha_ace[kid], np.eye(tmp.shape[0])))
 
-            # how's our cholesky decomposition looking?
-            assert (np.allclose(tmp, L @ L.conj().T))
+                tmp = -Cbeta[kid][:, :nmo].conj().T @ Ki_beta[kid]
+                L = np.linalg.cholesky(tmp)
 
-            Linv = np.linalg.inv(L)
-            Binv_beta_ace[kid] = -Linv.conj().T @ Linv
+                # how's our cholesky decomposition looking?
+                assert (np.allclose(tmp, L @ L.conj().T))
 
-            # how's our inverse looking?
-            assert (np.allclose(-tmp @ Binv_beta_ace[kid], np.eye(tmp.shape[0])))
+                Linv = np.linalg.inv(L)
+                Binv_beta_ace[kid] = -Linv.conj().T @ Linv
 
-            # for ace
+                # how's our inverse looking?
+                assert (np.allclose(-tmp @ Binv_beta_ace[kid], np.eye(tmp.shape[0])))
 
-            # (< phi_j | K) | c >
-            tmp = Ki_alpha[kid].conj().T @ Calpha[kid][:, :nmo]
-            # sum_j Binv_{ij} < phi_j | K | c > 
-            tmp = Binv_alpha_ace[kid] @ tmp 
-            # sum_i K | phi_i >  Binv_{ij} < phi_j | K | c >
-            ace_alpha = Ki_alpha[kid] @ tmp 
+                # for ace
 
-            # < phi_j | K | c >
-            tmp = Ki_beta[kid].conj().T @ Cbeta[kid][:, :nmo]
-            # sum_j Binv_{ij} < phi_j | K | c > 
-            tmp = Binv_beta_ace[kid] @ tmp 
-            # sum_i K | phi_i >  Binv_{ij} < phi_j | K | c >
-            ace_beta = Ki_beta[kid] @ tmp 
+                # (< phi_j | K) | c >
+                tmp = Ki_alpha[kid].conj().T @ Calpha[kid][:, :nmo]
+                # sum_j Binv_{ij} < phi_j | K | c > 
+                tmp = Binv_alpha_ace[kid] @ tmp 
+                # sum_i K | phi_i >  Binv_{ij} < phi_j | K | c >
+                ace_alpha = Ki_alpha[kid] @ tmp 
 
-            # is ace representation equivalent to original exact exchange representation?
-            assert (np.allclose(ace_alpha, exchange_alpha))
-            assert (np.allclose(ace_beta, exchange_beta))
+                # < phi_j | K | c >
+                tmp = Ki_beta[kid].conj().T @ Cbeta[kid][:, :nmo]
+                # sum_j Binv_{ij} < phi_j | K | c > 
+                tmp = Binv_beta_ace[kid] @ tmp 
+                # sum_i K | phi_i >  Binv_{ij} < phi_j | K | c >
+                ace_beta = Ki_beta[kid] @ tmp 
 
-            Fa_c += ace_alpha
-            Fb_c += ace_beta
+                # is ace representation equivalent to original exact exchange representation?
+                assert (np.allclose(ace_alpha, exchange_alpha))
+                assert (np.allclose(ace_beta, exchange_beta))
+
+                Fa_c += ace_alpha
+                Fb_c += ace_beta
             
             Fa_c += Vnl @ Calpha[kid][:, :nmo]
             Fb_c += Vnl @ Cbeta[kid][:, :nmo]

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -1340,16 +1340,16 @@ def uks(cell, basis,
                 #epsilon_beta[kid], Cbeta[kid] = scipy.linalg.eigh(fock_b[kid], eigvals=(0, nbeta))
 
             # break spin symmetry? # TODO this is broken, which probably indicates there is some other problem ...
-            if guess_mix is True and scf_iter == 0:
+            #if guess_mix is True and scf_iter == 0:
 
-                c = np.cos(0.05 * np.pi)
-                s = np.sin(0.05 * np.pi)
+            #    c = np.cos(0.05 * np.pi)
+            #    s = np.sin(0.05 * np.pi)
 
-                tmp1 = c * Calpha[kid][:, nalpha-1] - s * Calpha[kid][:, nalpha]
-                tmp2 = s * Calpha[kid][:, nalpha-1] + c * Calpha[kid][:, nalpha]
+            #    tmp1 = c * Calpha[kid][:, nalpha-1] - s * Calpha[kid][:, nalpha]
+            #    tmp2 = s * Calpha[kid][:, nalpha-1] + c * Calpha[kid][:, nalpha]
 
-                Calpha[kid][:, nalpha-1] = tmp1
-                Calpha[kid][:, nalpha] = tmp2
+            #    Calpha[kid][:, nalpha-1] = tmp1
+            #    Calpha[kid][:, nalpha] = tmp2
 
             # why do i need to orthonormalize my orbitals???
             Calpha[kid] = orthonormalize(Calpha[kid])

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -710,7 +710,7 @@ def uks(cell, basis,
         d_convergence = 1e-6, 
         diis_dimension = 8, 
         damp_fock = True, 
-        damping_iterations = 4,
+        damping_iterations = 8,
         ace_exchange = True,
         jellium = False,
         jellium_ne = 2,
@@ -800,7 +800,6 @@ def uks(cell, basis,
         damping_factor = 0.8
 
     # diis 
-    diis_dimension = 8
     diis_start_cycle = damping_iterations
 
     rs = (3 * basis.omega / ( 4.0 * np.pi * (nalpha + nbeta)))**(1.0/3.0)
@@ -849,38 +848,39 @@ def uks(cell, basis,
 
     # nmo ... number of desired molecular orbitals ... must be at least ne
     # warning: ace has trouble for nmo > ne with eigsh, but lobpcg seems to work
-    nmo = nalpha
-    if nbeta > nalpha:  
-        nmo = nbeta
+    nmo_alpha = nalpha + 1
+    nmo_beta = nbeta + 1
+    #if nbeta > nalpha:  
+    #    nmo = nbeta
 
     for kid in range ( len(basis.kpts) ):
 
-        Calpha.append(np.random.rand(basis.n_plane_waves_per_k[kid], nmo) * 1e-3)
-        Cbeta.append(np.random.rand(basis.n_plane_waves_per_k[kid], nmo) * 1e-3)
+        Calpha.append(np.random.rand(basis.n_plane_waves_per_k[kid], nmo_alpha) * 1e-3)
+        Cbeta.append(np.random.rand(basis.n_plane_waves_per_k[kid], nmo_beta) * 1e-3)
         #Calpha.append(np.zeros((basis.n_plane_waves_per_k[kid], nmo), dtype='complex128'))
         #Cbeta.append(np.zeros((basis.n_plane_waves_per_k[kid], nmo), dtype='complex128'))
-        for i in range (nmo):
+        for i in range (nmo_alpha):
             Calpha[kid][i, i] = 1.0
-        for i in range (nmo):
+        for i in range (nmo_beta):
             Cbeta[kid][i, i] = 1.0
         Calpha[kid] = orthonormalize(Calpha[kid])
         #Cbeta[kid] = orthonormalize(Cbeta[kid])
         Cbeta[kid] = Calpha[kid].copy()
 
 
-        Binv_alpha_ace.append(np.zeros((nmo, nmo), dtype='complex128'))
-        Binv_beta_ace.append(np.zeros((nmo, nmo), dtype='complex128'))
+        Binv_alpha_ace.append(np.zeros((nmo_alpha, nmo_alpha), dtype='complex128'))
+        Binv_beta_ace.append(np.zeros((nmo_beta, nmo_beta), dtype='complex128'))
 
-        Ki_alpha.append(np.zeros((basis.n_plane_waves_per_k[kid], nmo), dtype='complex128'))
-        Ki_beta.append(np.zeros((basis.n_plane_waves_per_k[kid], nmo), dtype='complex128'))
+        Ki_alpha.append(np.zeros((basis.n_plane_waves_per_k[kid], nmo_alpha), dtype='complex128'))
+        Ki_beta.append(np.zeros((basis.n_plane_waves_per_k[kid], nmo_beta), dtype='complex128'))
 
-        epsilon_alpha.append(np.zeros((nmo), dtype='complex128'))
-        epsilon_beta.append(np.zeros((nmo), dtype='complex128'))
+        epsilon_alpha.append(np.zeros((nmo_alpha), dtype='complex128'))
+        epsilon_beta.append(np.zeros((nmo_beta), dtype='complex128'))
 
     # diis extrapolates fock matrix
     from pyscf import lib
-    inner_diis = lib.diis.DIIS()
-    inner_diis.space = diis_dimension
+    diis = lib.diis.DIIS()
+    diis.space = diis_dimension
 
     # begin UKS iterations
     xc_energy = 0.0
@@ -913,8 +913,8 @@ def uks(cell, basis,
     inv_g2[mask] = 1.0 / basis.g2[mask]
 
     # so we have occ_alpha and occ_beta arrays ... won't work for kpts > 0
-    my_rho_a, occ_alpha = get_density(basis, Calpha[0], nalpha, nmo, kid)
-    my_rho_b, occ_beta = get_density(basis, Cbeta[0], nbeta, nmo, kid)
+    my_rho_a, occ_alpha = get_density(basis, Calpha[0], nalpha, nmo_alpha, kid)
+    my_rho_b, occ_beta = get_density(basis, Cbeta[0], nbeta, nmo_beta, kid)
 
     # kinetic energy
     T = []
@@ -1010,9 +1010,9 @@ def uks(cell, basis,
             if jellium:
                 Vnl *= 0.0
 
-            Fa_c = np.zeros((basis.n_plane_waves_per_k[kid], nmo), dtype='complex128')
-            exchange_alpha = np.zeros((basis.n_plane_waves_per_k[kid], nmo), dtype='complex128')
-            for i in range (nmo):
+            Fa_c = np.zeros((basis.n_plane_waves_per_k[kid], nmo_alpha), dtype='complex128')
+            exchange_alpha = np.zeros((basis.n_plane_waves_per_k[kid], nmo_alpha), dtype='complex128')
+            for i in range (nmo_alpha):
 
                 # exchange
                 Ki_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
@@ -1055,9 +1055,9 @@ def uks(cell, basis,
                 tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
                 exchange_alpha[:,i] = tmp[basis.kg_to_g[kid]] # map last term to small flattened basis
 
-            Fb_c = np.zeros((basis.n_plane_waves_per_k[kid], nmo), dtype='complex128')
-            exchange_beta = np.zeros((basis.n_plane_waves_per_k[kid], nmo), dtype='complex128')
-            for i in range (nmo):
+            Fb_c = np.zeros((basis.n_plane_waves_per_k[kid], nmo_beta), dtype='complex128')
+            exchange_beta = np.zeros((basis.n_plane_waves_per_k[kid], nmo_beta), dtype='complex128')
+            for i in range (nmo_beta):
 
                 # exchange
                 Ki_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
@@ -1102,7 +1102,7 @@ def uks(cell, basis,
             if xc == 'hf':
 
                 # for ace < phi_i | Kj>^{-1}
-                tmp = -Calpha[kid][:, :nmo].conj().T @ Ki_alpha[kid]
+                tmp = -Calpha[kid][:, :nmo_alpha].conj().T @ Ki_alpha[kid]
                 L = np.linalg.cholesky(tmp)
 
                 # how's our cholesky decomposition looking?
@@ -1114,7 +1114,7 @@ def uks(cell, basis,
                 # how's our inverse looking?
                 assert (np.allclose(-tmp @ Binv_alpha_ace[kid], np.eye(tmp.shape[0])))
 
-                tmp = -Cbeta[kid][:, :nmo].conj().T @ Ki_beta[kid]
+                tmp = -Cbeta[kid][:, :nmo_beta].conj().T @ Ki_beta[kid]
                 L = np.linalg.cholesky(tmp)
 
                 # how's our cholesky decomposition looking?
@@ -1129,14 +1129,14 @@ def uks(cell, basis,
                 # for ace
 
                 # (< phi_j | K) | c >
-                tmp = Ki_alpha[kid].conj().T @ Calpha[kid][:, :nmo]
+                tmp = Ki_alpha[kid].conj().T @ Calpha[kid][:, :nmo_alpha]
                 # sum_j Binv_{ij} < phi_j | K | c > 
                 tmp = Binv_alpha_ace[kid] @ tmp 
                 # sum_i K | phi_i >  Binv_{ij} < phi_j | K | c >
                 ace_alpha = Ki_alpha[kid] @ tmp 
 
                 # < phi_j | K | c >
-                tmp = Ki_beta[kid].conj().T @ Cbeta[kid][:, :nmo]
+                tmp = Ki_beta[kid].conj().T @ Cbeta[kid][:, :nmo_beta]
                 # sum_j Binv_{ij} < phi_j | K | c > 
                 tmp = Binv_beta_ace[kid] @ tmp 
                 # sum_i K | phi_i >  Binv_{ij} < phi_j | K | c >
@@ -1149,16 +1149,16 @@ def uks(cell, basis,
                 Fa_c += ace_alpha
                 Fb_c += ace_beta
             
-            Fa_c += Vnl @ Calpha[kid][:, :nmo]
-            Fb_c += Vnl @ Cbeta[kid][:, :nmo]
+            Fa_c += Vnl @ Calpha[kid][:, :nmo_alpha]
+            Fb_c += Vnl @ Cbeta[kid][:, :nmo_beta]
 
             #grad_a = Fa_c - epsilon_alpha[kid][np.newaxis, :nalpha] * Calpha[kid][:,:nalpha]
             #grad_b = Fb_c - epsilon_beta[kid][np.newaxis, :nbeta] * Cbeta[kid][:,:nbeta]
 
-            c_Fa_c = Calpha[kid][:, :nmo].conj().T @ Fa_c
-            c_Fb_c = Cbeta[kid][:, :nmo].conj().T @ Fb_c
-            grad_a = Fa_c - Calpha[kid][:,:nmo] @ c_Fa_c
-            grad_b = Fb_c - Cbeta[kid][:,:nmo] @ c_Fb_c
+            c_Fa_c = Calpha[kid][:, :nmo_alpha].conj().T @ Fa_c
+            c_Fb_c = Cbeta[kid][:, :nmo_beta].conj().T @ Fb_c
+            grad_a = Fa_c - Calpha[kid][:,:nmo_alpha] @ c_Fa_c
+            grad_b = Fb_c - Cbeta[kid][:,:nmo_beta] @ c_Fb_c
 
             error_vector = np.hstack( (error_vector, grad_a.flatten(), grad_b.flatten() ) )
 
@@ -1179,7 +1179,7 @@ def uks(cell, basis,
 
         solution_vector = np.hstack( (rho_alpha.flatten(), rho_beta.flatten()) )
         #solution_vector = np.hstack( (v_alpha, v_beta) )
-        new_solution_vector = inner_diis.update(solution_vector, error_vector)
+        new_solution_vector = diis.update(solution_vector, error_vector)
         #v_alpha = new_solution_vector[:len(v_alpha)]
         #v_beta = new_solution_vector[len(v_alpha):]
         rho_alpha = new_solution_vector[:len(solution_vector)//2].reshape(rho_alpha_old.shape)
@@ -1339,27 +1339,27 @@ def uks(cell, basis,
                 epsilon_alpha[kid], Calpha[kid] = scipy.linalg.eigh(np.diag(T[kid]), eigvals=(0, nalpha))
                 #epsilon_beta[kid], Cbeta[kid] = scipy.linalg.eigh(fock_b[kid], eigvals=(0, nbeta))
 
+            # break spin symmetry? # TODO this is broken, which probably indicates there is some other problem ...
+            if guess_mix is True and scf_iter == 0:
+
+                c = np.cos(0.05 * np.pi)
+                s = np.sin(0.05 * np.pi)
+
+                tmp1 = c * Calpha[kid][:, nalpha-1] - s * Calpha[kid][:, nalpha]
+                tmp2 = s * Calpha[kid][:, nalpha-1] + c * Calpha[kid][:, nalpha]
+
+                Calpha[kid][:, nalpha-1] = tmp1
+                Calpha[kid][:, nalpha] = tmp2
+
             # why do i need to orthonormalize my orbitals???
             Calpha[kid] = orthonormalize(Calpha[kid])
             Cbeta[kid] = orthonormalize(Cbeta[kid])
             if jellium:
                 Cbeta[kid] = Calpha[kid].copy()
 
-            # break spin symmetry? # TODO this is broken, which probably indicates there is some other problem ...
-            #if guess_mix is True and scf_iter == 0:
-
-            #    c = np.cos(0.25 * np.pi)
-            #    s = np.sin(0.25 * np.pi)
-
-            #    tmp1 = c * Calpha[kid][:, nalpha-1] - s * Calpha[kid][:, nalpha]
-            #    tmp2 = s * Calpha[kid][:, nalpha-1] + c * Calpha[kid][:, nalpha]
-
-            #    Calpha[kid][:, nalpha-1] = tmp1
-            #    Calpha[kid][:, nalpha] = tmp2
-
             # update density
-            my_rho_alpha, occ_alpha = get_density(basis, Calpha[kid], nalpha, nmo, kid)
-            my_rho_beta, occ_beta = get_density(basis, Cbeta[kid], nbeta, nmo, kid)
+            my_rho_alpha, occ_alpha = get_density(basis, Calpha[kid], nalpha, nmo_alpha, kid)
+            my_rho_beta, occ_beta = get_density(basis, Cbeta[kid], nbeta, nmo_beta, kid)
 
             # density should be non-negative ...
             rho_alpha += my_rho_alpha.clip(min = 0)

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -19,7 +19,7 @@ import time
 import warnings
 import numpy as np
 import scipy
-from scipy.sparse.linalg import LinearOperator, lobpcg
+from scipy.sparse.linalg import LinearOperator
 
 from qcpanop.pw_pbc.pseudopotential import get_local_pseudopotential_gth
 from qcpanop.pw_pbc.pseudopotential import get_nonlocal_pseudopotential_matrix_elements
@@ -534,24 +534,25 @@ def form_orbital_gradient(basis, C, N, F, kid):
 
     return orbital_gradient
 
-def get_density(basis, C, N, kid):
+def get_density(basis, C, Ne, Nmo, kid):
     """
 
     get real-space density from molecular orbital coefficients
 
     :param basis: plane wave basis information
     :param C: molecular orbital coefficients
-    :param N: the number of electrons
+    :param Ne: the number of electrons
+    :param Nmo: the number of molecular orbitals (Nmo >= Ne)
     :param kid: index for a given k-point
 
     :return rho: the density
-    :return occupied_orbitals: the occupied orbitals in real space 
+    :return orbitals_r: the molecular orbitals in real space 
 
     """
 
-    occupied_orbitals = []
+    orbitals_r = []
     rho = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
-    for pp in range(N):
+    for pp in range(Nmo):
 
         occ = np.zeros(basis.real_space_grid_dim,dtype = 'complex128')
 
@@ -561,11 +562,12 @@ def get_density(basis, C, N, kid):
             occ[ get_miller_indices(ik, basis) ] = C[tt, pp]
 
         occ = np.fft.fftn(occ) 
-        occupied_orbitals.append( occ )
+        orbitals_r.append(occ)
 
-        rho += np.absolute(occ)**2.0 / basis.omega
+        if pp < Ne:
+            rho += np.absolute(occ)**2.0 / basis.omega
 
-    return ( 1.0 / len(basis.kpts) ) * rho, occupied_orbitals
+    return ( 1.0 / len(basis.kpts) ) * rho, orbitals_r
 
 def form_fock_matrix(basis, kid, v = None): 
     """
@@ -808,7 +810,7 @@ def uks(cell, basis,
     # damp fock matrix (helps with convergence sometimes)
     damping_factor = 1.0
     if damp_fock :
-        damping_factor = 0.2
+        damping_factor = 0.5
 
     # diis 
     diis_dimension = 8
@@ -853,25 +855,35 @@ def uks(cell, basis,
     Ki_alpha = []
     Ki_beta = []
 
+    # nmo ... number of desired molecular orbitals ... must be at least ne
+    # TODO: ace doesn't always work correctly for nmo > ne
+    nmo = nalpha
+    if nbeta > nalpha: 
+        nmo = nbeta
+
     for kid in range ( len(basis.kpts) ):
 
-        Calpha.append(np.random.rand(basis.n_plane_waves_per_k[kid], nalpha + 1) * 1e-8)
-        Cbeta.append(np.random.rand(basis.n_plane_waves_per_k[kid], nbeta + 1) * 1e-8)
+        Calpha.append(np.random.rand(basis.n_plane_waves_per_k[kid], nmo) * 1e-8)
+        Cbeta.append(np.random.rand(basis.n_plane_waves_per_k[kid], nmo) * 1e-8)
+        #for i in range (nmo):
+        #    Calpha[kid][i, i] = 1.0
+        #for i in range (nmo):
+        #    Cbeta[kid][i, i] = 1.0
+        #Calpha[kid] = orthonormalize(Calpha[kid])
+        #Cbeta[kid] = orthonormalize(Cbeta[kid])
 
         #Calpha.append(np.zeros((basis.n_plane_waves_per_k[kid], nalpha+1), dtype='complex128'))
         #Cbeta.append(np.zeros((basis.n_plane_waves_per_k[kid], nbeta+1), dtype='complex128'))
 
-        #Calpha[kid] = orthonormalize(Calpha[kid])
-        #Cbeta[kid] = orthonormalize(Cbeta[kid])
 
-        Binv_alpha_ace.append(np.zeros((nalpha, nalpha), dtype='complex128'))
-        Binv_beta_ace.append(np.zeros((nbeta, nbeta), dtype='complex128'))
+        Binv_alpha_ace.append(np.zeros((nmo, nmo), dtype='complex128'))
+        Binv_beta_ace.append(np.zeros((nmo, nmo), dtype='complex128'))
 
-        Ki_alpha.append(np.zeros((basis.n_plane_waves_per_k[kid], nalpha), dtype='complex128'))
-        Ki_beta.append(np.zeros((basis.n_plane_waves_per_k[kid], nbeta), dtype='complex128'))
+        Ki_alpha.append(np.zeros((basis.n_plane_waves_per_k[kid], nmo), dtype='complex128'))
+        Ki_beta.append(np.zeros((basis.n_plane_waves_per_k[kid], nmo), dtype='complex128'))
 
-        epsilon_alpha.append(np.zeros((nalpha+1), dtype='complex128'))
-        epsilon_beta.append(np.zeros((nbeta+1), dtype='complex128'))
+        epsilon_alpha.append(np.zeros((nmo), dtype='complex128'))
+        epsilon_beta.append(np.zeros((nmo), dtype='complex128'))
 
     # diis extrapolates fock matrix
     from pyscf import lib
@@ -909,8 +921,8 @@ def uks(cell, basis,
     inv_g2[mask] = 1.0 / basis.g2[mask]
 
     # so we have occ_alpha and occ_beta arrays ... won't work for kpts > 0
-    my_rho_a, occ_alpha = get_density(basis, Calpha[0], nalpha, kid)
-    my_rho_b, occ_beta = get_density(basis, Cbeta[0], nbeta, kid)
+    my_rho_a, occ_alpha = get_density(basis, Calpha[0], nalpha, nmo, kid)
+    my_rho_b, occ_beta = get_density(basis, Cbeta[0], nbeta, nmo, kid)
 
     # kinetic energy
     T = []
@@ -969,9 +981,9 @@ def uks(cell, basis,
             # jellium
             #Vnl *= 0.0
 
-            Fa_c = np.zeros((basis.n_plane_waves_per_k[kid], nalpha), dtype='complex128')
-            exchange_alpha = np.zeros((basis.n_plane_waves_per_k[kid], nalpha), dtype='complex128')
-            for i in range (nalpha):
+            Fa_c = np.zeros((basis.n_plane_waves_per_k[kid], nmo), dtype='complex128')
+            exchange_alpha = np.zeros((basis.n_plane_waves_per_k[kid], nmo), dtype='complex128')
+            for i in range (nmo):
 
                 # exchange
                 Ki_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
@@ -1014,9 +1026,9 @@ def uks(cell, basis,
                 tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
                 exchange_alpha[:,i] = tmp[basis.kg_to_g[kid]] # map last term to small flattened basis
 
-            Fb_c = np.zeros((basis.n_plane_waves_per_k[kid], nbeta), dtype='complex128')
-            exchange_beta = np.zeros((basis.n_plane_waves_per_k[kid], nalpha), dtype='complex128')
-            for i in range (nbeta):
+            Fb_c = np.zeros((basis.n_plane_waves_per_k[kid], nmo), dtype='complex128')
+            exchange_beta = np.zeros((basis.n_plane_waves_per_k[kid], nmo), dtype='complex128')
+            for i in range (nmo):
 
                 # exchange
                 Ki_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
@@ -1059,60 +1071,62 @@ def uks(cell, basis,
                 exchange_beta[:,i] = tmp[basis.kg_to_g[kid]] # map last term to small flattened basis
 
             # for ace < phi_i | Kj>^{-1}
-            if scf_iter > 0 :
+            tmp = -Calpha[kid][:, :nmo].conj().T @ Ki_alpha[kid]
+            L = np.linalg.cholesky(tmp)
+            # how's our cholesky decomposition looking?
+            assert (np.allclose(tmp, L @ L.conj().T))
 
-                tmp = -Calpha[kid][:, :nalpha].conj().T @ Ki_alpha[kid]
-                L = np.linalg.cholesky(tmp)
-                Linv = np.linalg.inv(L)
-                Binv_alpha_ace[kid] = -Linv.conj().T @ Linv
+            Linv = np.linalg.inv(L)
+            Binv_alpha_ace[kid] = -Linv.conj().T @ Linv
 
-                # how's our inverse looking?
-                assert (np.allclose(-tmp @ Binv_alpha_ace[kid], np.eye(tmp.shape[0])))
+            # how's our inverse looking?
+            assert (np.allclose(-tmp @ Binv_alpha_ace[kid], np.eye(tmp.shape[0])))
 
-                tmp = -Cbeta[kid][:, :nbeta].conj().T @ Ki_beta[kid]
-                L = np.linalg.cholesky(tmp)
-                Linv = np.linalg.inv(L)
-                Binv_beta_ace[kid] = -Linv.conj().T @ Linv
+            tmp = -Cbeta[kid][:, :nmo].conj().T @ Ki_beta[kid]
+            tmp = 0.5 * (tmp + tmp.conj().T)
+            L = np.linalg.cholesky(tmp)
+            # how's our cholesky decomposition looking?
+            assert (np.allclose(tmp, L @ L.conj().T))
 
-                # how's our inverse looking?
-                assert (np.allclose(-tmp @ Binv_beta_ace[kid], np.eye(tmp.shape[0])))
+            Linv = np.linalg.inv(L)
+            Binv_beta_ace[kid] = -Linv.conj().T @ Linv
 
-            else:
-                pass
+            # how's our inverse looking?
+            assert (np.allclose(-tmp @ Binv_beta_ace[kid], np.eye(tmp.shape[0])))
 
             # for ace
 
             # (< phi_j | K) | c >
-            tmp = Ki_alpha[kid].conj().T @ Calpha[kid][:, :nalpha]
+            tmp = Ki_alpha[kid].conj().T @ Calpha[kid][:, :nmo]
             # sum_j Binv_{ij} < phi_j | K | c > 
             tmp = Binv_alpha_ace[kid] @ tmp 
             # sum_i K | phi_i >  Binv_{ij} < phi_j | K | c >
             ace_alpha = Ki_alpha[kid] @ tmp 
 
             # < phi_j | K | c >
-            tmp = Ki_beta[kid].conj().T @ Cbeta[kid][:, :nbeta]
+            tmp = Ki_beta[kid].conj().T @ Cbeta[kid][:, :nmo]
             # sum_j Binv_{ij} < phi_j | K | c > 
             tmp = Binv_beta_ace[kid] @ tmp 
             # sum_i K | phi_i >  Binv_{ij} < phi_j | K | c >
             ace_beta = Ki_beta[kid] @ tmp 
 
             # is ace representation equivalent to original exact exchange representation?
-            #assert (np.allclose(ace_alpha, exchange_alpha))
-            #assert (np.allclose(ace_beta, exchange_beta))
+            assert (np.allclose(ace_alpha, exchange_alpha))
+            assert (np.allclose(ace_beta, exchange_beta))
 
             Fa_c += ace_alpha
             Fb_c += ace_beta
             
-            Fa_c += Vnl @ Calpha[kid][:, :nalpha]
-            Fb_c += Vnl @ Cbeta[kid][:, :nbeta]
+            Fa_c += Vnl @ Calpha[kid][:, :nmo]
+            Fb_c += Vnl @ Cbeta[kid][:, :nmo]
 
             #grad_a = Fa_c - epsilon_alpha[kid][np.newaxis, :nalpha] * Calpha[kid][:,:nalpha]
             #grad_b = Fb_c - epsilon_beta[kid][np.newaxis, :nbeta] * Cbeta[kid][:,:nbeta]
 
-            c_Fa_c = Calpha[kid][:, :nalpha].conj().T @ Fa_c
-            c_Fb_c = Cbeta[kid][:, :nbeta].conj().T @ Fb_c
-            grad_a = Fa_c - Calpha[kid][:,:nalpha] @ c_Fa_c
-            grad_b = Fb_c - Cbeta[kid][:,:nbeta] @ c_Fb_c
+            c_Fa_c = Calpha[kid][:, :nmo].conj().T @ Fa_c
+            c_Fb_c = Cbeta[kid][:, :nmo].conj().T @ Fb_c
+            grad_a = Fa_c - Calpha[kid][:,:nmo] @ c_Fa_c
+            grad_b = Fb_c - Cbeta[kid][:,:nmo] @ c_Fb_c
 
             error_vector = np.hstack( (error_vector, grad_a.flatten(), grad_b.flatten() ) )
 
@@ -1244,14 +1258,16 @@ def uks(cell, basis,
             my_v_r = v_alpha_r.copy()
             my_Ki = Ki_alpha[kid].copy()
             my_Binv = Binv_alpha_ace[kid].copy()
-            epsilon_alpha[kid], Calpha[kid] = scipy.sparse.linalg.eigsh(F_C, k=nalpha+1, which="SA", v0 = Calpha[kid][:,0])
+            epsilon_alpha[kid], Calpha[kid] = scipy.sparse.linalg.eigsh(F_C, k=nmo, which="SA", v0 = Calpha[kid][:,0])
+            #epsilon_alpha[kid], Calpha[kid] = scipy.sparse.linalg.lobpcg(F_C, Calpha[kid], largest=False)
 
             my_N = nbeta
             occ_list = occ_beta.copy()
             my_v_r = v_beta_r.copy()
             my_Ki = Ki_beta[kid].copy()
             my_Binv = Binv_beta_ace[kid].copy()
-            epsilon_beta[kid], Cbeta[kid] = scipy.sparse.linalg.eigsh(F_C, k=nbeta+1, which="SA", v0 = Cbeta[kid][:,0])
+            epsilon_beta[kid], Cbeta[kid] = scipy.sparse.linalg.eigsh(F_C, k=nmo, which="SA", v0 = Cbeta[kid][:,0])
+            #epsilon_beta[kid], Cbeta[kid] = scipy.sparse.linalg.lobpcg(F_C, Cbeta[kid], largest=False)
 
             #epsilon_alpha[kid], Calpha[kid] = scipy.linalg.eigh(fock_a[kid], eigvals=(0, nalpha))
             #epsilon_beta[kid], Cbeta[kid] = scipy.linalg.eigh(fock_b[kid], eigvals=(0, nbeta))
@@ -1273,8 +1289,8 @@ def uks(cell, basis,
             #    Calpha[kid][:, nalpha] = tmp2
 
             # update density
-            my_rho_alpha, occ_alpha = get_density(basis, Calpha[kid], nalpha, kid)
-            my_rho_beta, occ_beta = get_density(basis, Cbeta[kid], nbeta, kid)
+            my_rho_alpha, occ_alpha = get_density(basis, Calpha[kid], nalpha, nmo, kid)
+            my_rho_beta, occ_beta = get_density(basis, Cbeta[kid], nbeta, nmo, kid)
 
             # density should be non-negative ...
             rho_alpha += my_rho_alpha.clip(min = 0)

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -15,9 +15,11 @@ functional_name_dict = {
 } 
 
 
+import time
 import warnings
 import numpy as np
 import scipy
+from scipy.sparse.linalg import LinearOperator, lobpcg
 
 from qcpanop.pw_pbc.pseudopotential import get_local_pseudopotential_gth
 from qcpanop.pw_pbc.pseudopotential import get_nonlocal_pseudopotential_matrix_elements
@@ -25,6 +27,26 @@ from qcpanop.pw_pbc.pseudopotential import get_nonlocal_pseudopotential_matrix_e
 from qcpanop.pw_pbc.basis import get_miller_indices
 
 from pyscf.pbc import tools
+
+def orthonormalize(C):
+
+    """
+    orthonormalize orbitals (plane-wave coefficients).
+    :param C: orbitals
+    :return C_new: orthonormalized orbitals
+    """
+
+    # overlap matrix
+    S = C.conj().T @ C
+
+    # diagonalize overlap
+    evals, evecs = np.linalg.eigh(S)
+
+    # form S^{-1/2}
+    S_inv_sqrt = (evecs / np.sqrt(evals)) @ evecs.conj().T
+
+    # apply to orbitals
+    return C @ S_inv_sqrt
 
 def get_exact_exchange_energy(basis, occupied_orbitals, N, C, exchange_matrix, compute_exchange_matrix = False):
     """
@@ -87,6 +109,7 @@ def get_exact_exchange_energy(basis, occupied_orbitals, N, C, exchange_matrix, c
     # build exchange matrix in planewave basis
 
     Kij_G = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
+
     for i in range(0, basis.n_plane_waves_per_k[0]):
         ii = basis.kg_to_g[0][i]
 
@@ -125,6 +148,40 @@ def get_exact_exchange_energy(basis, occupied_orbitals, N, C, exchange_matrix, c
             kk = basis.kg_to_g[0][k]
             
             exchange_matrix[k, i] = row_g[ get_miller_indices(kk, basis) ] 
+
+    # build exchange matrix in occupied orbital basis, then transform to planewave basis
+
+    #Ki_G = np.zeros(basis.n_plane_waves_per_k[0], dtype = 'complex128')
+    #for i in range(0, N):
+
+    #    # Ki(r) = sum_j Kij(r) phi_j(r)
+    #    Ki_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
+
+    #    for j in range(0, N):
+
+    #        # Cij(r') = phi_i(r') phi_j*(r')
+    #        # Cij(g) = FFT[Cij(r')]
+    #        tmp = np.fft.ifftn(occupied_orbitals[j].conj() * occupied_orbitals[i])
+    #        Cij = tmp.ravel()[flat_idx]
+
+    #        # Kij(g) = Cij(g) * FFT[1/|r-r'|]
+    #        Kij_G.ravel()[flat_idx] = Cij * inv_g2 #Kij
+
+    #        # Kij(r) = FFT^-1[Kij(g)]
+    #        Kij_r = np.fft.fftn(Kij_G)
+
+    #        # action of K on an occupied orbital, i: 
+    #        # Ki(r) = sum_j Kij(r) phi_j(r)
+    #        Ki_r += Kij_r * occupied_orbitals[j]
+
+    #    # Ki(G) 
+    #    Ki_G_big = np.fft.ifftn(Ki_r).ravel()[flat_idx]
+    #    for i_orb in range( basis.n_plane_waves_per_k[0] ):
+    #        i_dens = basis.kg_to_g[0][i_orb]
+    #        Ki_G[i_orb] = Ki_G_big[i_dens]
+
+    #    # accumulate exchange matrix
+    #    exchange_matrix += np.outer(Ki_G, C[0][:, i].conj())
 
     return -2.0 * np.pi / basis.omega * exchange_energy, -4.0 * np.pi / basis.omega * exchange_matrix
 
@@ -528,13 +585,14 @@ def form_fock_matrix(basis, kid, v = None):
     if v is not None:
         fock += get_matrix_elements(basis, kid, v)
     
-    # get non-local part of the pseudopotential
-    if basis.use_pseudopotential:
-        fock += get_nonlocal_pseudopotential_matrix_elements(basis, kid, use_legendre = basis.nl_pp_use_legendre)
+    # get non-local part of the pseudopotential (not jellium)
+    #if basis.use_pseudopotential:
+    #    fock += get_nonlocal_pseudopotential_matrix_elements(basis, kid, use_legendre = basis.nl_pp_use_legendre)
 
     # get kinetic energy
     kgtmp = basis.kpts[kid] + basis.g[basis.kg_to_g[kid, :basis.n_plane_waves_per_k[kid]]]
-    diagonals = np.einsum('ij,ij->i', kgtmp, kgtmp) / 2.0 + fock.diagonal()
+    T = np.einsum('ij,ij->i', kgtmp, kgtmp) / 2.0 
+    diagonals = T + fock.diagonal()
     np.fill_diagonal(fock, diagonals)
 
     # only upper triangle of fock is populated ... symmetrize and rescale diagonal
@@ -543,6 +601,43 @@ def form_fock_matrix(basis, kid, v = None):
     np.fill_diagonal(fock, 0.5 * diag)
 
     return fock
+
+def form_part_of_fock_matrix(basis, kid, v = None): 
+    """
+
+    form fock matrix
+
+    :param basis: plane wave basis information
+    :param kid: index for a given k-point
+    :param v: the potential ( coulomb + xc + electron-nucleus / local pp )
+
+    :return fock: the fock matrix
+
+    """
+
+    fock = np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128')
+
+    # unpack potential
+    if v is not None:
+        fock += get_matrix_elements(basis, kid, v)
+    
+    # get non-local part of the pseudopotential
+    if basis.use_pseudopotential:
+        fock += get_nonlocal_pseudopotential_matrix_elements(basis, kid, use_legendre = basis.nl_pp_use_legendre)
+
+    # get kinetic energy
+    kgtmp = basis.kpts[kid] + basis.g[basis.kg_to_g[kid, :basis.n_plane_waves_per_k[kid]]]
+    T = np.einsum('ij,ij->i', kgtmp, kgtmp) / 2.0 
+    diagonals = T + fock.diagonal()
+    np.fill_diagonal(fock, diagonals)
+
+    # only upper triangle of fock is populated ... symmetrize and rescale diagonal
+    fock = fock + fock.conj().T
+    diag = np.diag(fock)
+    np.fill_diagonal(fock, 0.5 * diag)
+
+    return fock
+
 
 def get_one_electron_energy(basis, C, N, kid, v_ne = None):
     """
@@ -569,8 +664,8 @@ def get_one_electron_energy(basis, C, N, kid, v_ne = None):
         oei += get_nonlocal_pseudopotential_matrix_elements(basis, kid, use_legendre = basis.nl_pp_use_legendre)
 
     kgtmp = basis.kpts[kid] + basis.g[basis.kg_to_g[kid, :basis.n_plane_waves_per_k[kid]]]
-
-    diagonals = np.einsum('ij,ij->i', kgtmp, kgtmp) / 2.0 + oei.diagonal()
+    T = np.einsum('ij,ij->i', kgtmp, kgtmp) / 2.0 
+    diagonals = T + oei.diagonal()
     np.fill_diagonal(oei, diagonals)
 
     oei = oei + oei.conj().T
@@ -703,6 +798,11 @@ def uks(cell, basis,
     nalpha, nbeta = cell.nelec
     total_charge = cell.charge
 
+    # jellium
+    #v_ne *= 0.0
+    #nalpha = 6
+    #nbeta = 6
+
     # damp fock matrix (helps with convergence sometimes)
     damping_factor = 1.0
     if damp_fock :
@@ -747,6 +847,9 @@ def uks(cell, basis,
     old_fock_a = []
     old_fock_b = []
 
+    epsilon_alpha = []
+    epsilon_beta = []
+
     for kid in range ( len(basis.kpts) ):
 
         fock_a.append(np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128'))
@@ -755,8 +858,17 @@ def uks(cell, basis,
         old_fock_a.append(np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128'))
         old_fock_b.append(np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128'))
 
-        Calpha.append(np.eye(basis.n_plane_waves_per_k[kid]))
-        Cbeta.append(np.eye(basis.n_plane_waves_per_k[kid]))
+        #Calpha.append(np.eye(basis.n_plane_waves_per_k[kid]))
+        #Cbeta.append(np.eye(basis.n_plane_waves_per_k[kid]))
+
+        #Calpha.append(np.random.rand(basis.n_plane_waves_per_k[kid], nalpha + 1))
+        #Cbeta.append(np.random.rand(basis.n_plane_waves_per_k[kid], nbeta))
+
+        Calpha.append(np.zeros((basis.n_plane_waves_per_k[kid], nalpha+1), dtype='complex128'))
+        Cbeta.append(np.zeros((basis.n_plane_waves_per_k[kid], nbeta+1), dtype='complex128'))
+
+        epsilon_alpha.append(np.zeros((nalpha+1), dtype='complex128'))
+        epsilon_beta.append(np.zeros((nbeta+1), dtype='complex128'))
 
     # diis extrapolates fock matrix
     from pyscf import lib
@@ -768,92 +880,225 @@ def uks(cell, basis,
     scf_iter = 0 # initialize variable incase maxiter = 0
     one_electron_energy = 0.0
     coulomb_energy = 0.0
-    recompute_exchange = False
+    recompute_exchange = True
+
+    # precompute indices
+
+    # FFT grid shape
+    grid_shape = basis.real_space_grid_dim  # e.g., (nx, ny, nz)
+    
+    # for each compact G index `myg`, find its flat index in FFT grid ordering
+    flat_idx = np.empty(len(basis.g), dtype=np.int64)
+    for myg in range(len(basis.g)):
+        ix, iy, iz = get_miller_indices(myg, basis)
+        flat_idx[myg] = np.ravel_multi_index((ix, iy, iz), grid_shape)
+
+    # precompute linear grid indices for each k-point
+    grid_idx_k = []
+    for kid in range ( len(basis.kpts) ):
+        ijk = np.array([get_miller_indices(ik, basis) for ik in basis.kg_to_g[kid]])
+        coords = tuple(ijk.T)
+        grid_idx_k.append(np.ravel_multi_index(coords, grid_shape))
+
+    # precompute FFT[1/|r-r'|/g2]
+    inv_g2 = np.zeros_like(basis.g2)
+    mask = basis.g2 != 0.0
+    inv_g2[mask] = 1.0 / basis.g2[mask]
+
+    # so we have occ_alpha and occ_beta arrays ... won't work for kpts > 0
+    my_rho_a, occ_alpha = get_density(basis, Calpha[0], nalpha, kid)
+    my_rho_b, occ_beta = get_density(basis, Cbeta[0], nbeta, kid)
+
+    # kinetic energy
+    T = []
+    for kid in range ( len(basis.kpts) ):
+        kgtmp = basis.kpts[kid] + basis.g[basis.kg_to_g[kid, :basis.n_plane_waves_per_k[kid]]]
+        T.append(np.einsum('ij,ij->i', kgtmp, kgtmp) / 2.0)
+
+    #fock_a = []
+    #fock_b = []
+    #for kid in range ( len(basis.kpts) ):
+    #    fock_a.append(np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128'))
+    #    fock_b.append(np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128'))
+
+    va = 0 * v_ne
+    vb = 0 * v_ne
+    va_old = 0 * v_ne
+    vb_old = 0 * v_ne
 
     for scf_iter in range(maxiter):
-
-        occ_alpha = []
-        occ_beta = []
 
         one_electron_energy = 0.0
         coulomb_energy = 0.0
 
+        va_old = va
+        vb_old = vb
         if xc != 'hf' :
-            va = v_coulomb + v_ne + v_xc_alpha
-            vb = v_coulomb + v_ne + v_xc_beta
+            va = v_coulomb + v_xc_alpha
+            vb = v_coulomb + v_xc_beta
         else :
-            va = v_coulomb + v_ne 
-            vb = v_coulomb + v_ne 
+            va = v_coulomb
+            vb = v_coulomb
+
+        # potential in real space
+        va_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
+        va_r.ravel()[flat_idx] = va + v_ne
+        va_r = np.fft.fftn(va_r)
+
+        vb_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
+        vb_r.ravel()[flat_idx] = vb + v_ne
+        vb_r = np.fft.fftn(vb_r)
 
         # zero density for this iteration
         rho = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
-
-        # form fock matrix and orbital gradient
-
-        fock_a = []
-        fock_b = []
-        grad_a = []
-        grad_b = []
-
-        for kid in range ( len(basis.kpts) ):
-            fock_a.append(np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128'))
-            fock_b.append(np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128'))
-            grad_a.append(np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128'))
-            grad_b.append(np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128'))
 
         # damping factor
         damp = 1.0
         if scf_iter < diis_start_cycle and damp_fock : 
             damp = damping_factor
 
-        # loop over k-points
+        # orbital gradient
+        error_vector = np.zeros(0)
+
+        Kij_G = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
+
         for kid in range( len(basis.kpts) ):
 
-            # form fock matrix
-            fock_a[kid] = form_fock_matrix(basis, kid, v = va)
-            fock_b[kid] = form_fock_matrix(basis, kid, v = vb)
+            Vnl = get_nonlocal_pseudopotential_matrix_elements(basis, kid, use_legendre = basis.nl_pp_use_legendre)
+            Vnl = Vnl + Vnl.conj().T
+            diag = np.diag(Vnl)
+            np.fill_diagonal(Vnl, 0.5 * diag)
 
-            # exact exchange?
-            if xc == 'hf' :
-                fock_a += exchange_matrix_alpha
-                fock_b += exchange_matrix_beta
+            # jellium
+            #Vnl *= 0.0
 
-            # damp fock matrix
-            fock_a[kid] = damp * fock_a[kid] + (1.0 - damp) * old_fock_a[kid]
-            fock_b[kid] = damp * fock_b[kid] + (1.0 - damp) * old_fock_b[kid]
-            old_fock_a[kid] = fock_a[kid].copy()
-            old_fock_b[kid] = fock_b[kid].copy()
+            Fa_c = np.zeros((basis.n_plane_waves_per_k[kid], nalpha), dtype='complex128')
+            for i in range (nalpha):
 
-            # form opdm and orbital gradient (for diis)
-            grad_a[kid] = form_orbital_gradient(basis, Calpha[kid], nalpha, fock_a[kid], kid)
-            grad_b[kid] = form_orbital_gradient(basis, Cbeta[kid], nbeta, fock_b[kid], kid)
+                # exchange
+                Ki_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
+                if xc == 'hf':
+                    for j in range(0, nalpha):
 
-        # extrapolate fock matrix
+                        # Cij(r') = phi_i(r') phi_j*(r')
+                        # Cij(g) = FFT[Cij(r')]
+                        tmp = np.fft.ifftn(occ_alpha[j].conj() * occ_alpha[i])
+                        Cij = tmp.ravel()[flat_idx]
 
-        # solution vector is fock matrix
-        solution_vector = np.zeros(0)
-        for kid in range ( len(basis.kpts) ):
-            solution_vector = np.hstack( (solution_vector, fock_a[kid].flatten(), fock_b[kid].flatten() ) )
+                        # Kij(g) = Cij(g) * FFT[1/|r-r'|]
+                        Kij_G.ravel()[flat_idx] = Cij * inv_g2 #Kij
 
-        # error vector is orbital gradient
-        error_vector = np.zeros(0)
-        for kid in range ( len(basis.kpts) ):
-            error_vector = np.hstack( (error_vector, grad_a[kid].flatten(), grad_b[kid].flatten() ) )
+                        # Kij(r) = FFT^-1[Kij(g)]
+                        Kij_r = np.fft.fftn(Kij_G)
+
+                        # action of K on an occupied orbital, i: 
+                        # Ki(r) = sum_j Kij(r) phi_j(r)
+                        Ki_r += Kij_r * occ_alpha[j]
+
+                    Ki_r *= -4.0 * np.pi / basis.omega
+
+                # action of potential on orbitals in real space, then transform to reciprocal space
+                tmp = va_r * occ_alpha[i] + Ki_r # real space, 3d
+                tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
+                tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
+
+                Fa_c[:,i] = T[kid] * Calpha[kid][:, i] + tmp[basis.kg_to_g[kid]]
+
+            Fb_c = np.zeros((basis.n_plane_waves_per_k[kid], nbeta), dtype='complex128')
+            for i in range (nbeta):
+
+                # exchange
+                Ki_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
+                if xc == 'hf':
+                    for j in range(0, nbeta):
+
+                        # Cij(r') = phi_i(r') phi_j*(r')
+                        # Cij(g) = FFT[Cij(r')]
+                        tmp = np.fft.ifftn(occ_beta[j].conj() * occ_beta[i])
+                        Cij = tmp.ravel()[flat_idx]
+
+                        # Kij(g) = Cij(g) * FFT[1/|r-r'|]
+                        Kij_G.ravel()[flat_idx] = Cij * inv_g2 #Kij
+
+                        # Kij(r) = FFT^-1[Kij(g)]
+                        Kij_r = np.fft.fftn(Kij_G)
+
+                        # action of K on an occupied orbital, i: 
+                        # Ki(r) = sum_j Kij(r) phi_j(r)
+                        Ki_r += Kij_r * occ_beta[j]
+
+                    Ki_r *= -4.0 * np.pi / basis.omega
+
+                # action of potential on orbitals in real space, then transform to reciprocal space
+                tmp = vb_r * occ_beta[i] + Ki_r # real space, 3d
+                tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
+                tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
+
+                Fb_c[:,i] = T[kid] * Cbeta[kid][:, i] + tmp[basis.kg_to_g[kid]]
+
+            fock_a[kid] = form_fock_matrix(basis, kid, v = va + v_ne) + Vnl + exchange_matrix_alpha
+            fock_b[kid] = form_fock_matrix(basis, kid, v = vb + v_ne) + Vnl + exchange_matrix_beta
+
+            Fa_c = fock_a[kid] @ Calpha[kid][:, :nalpha]
+            Fb_c = fock_b[kid] @ Cbeta[kid][:, :nbeta]
+
+            #Fa_c += Vnl @ Calpha[kid][:, :nalpha]
+            #Fb_c += Vnl @ Cbeta[kid][:, :nbeta]
+
+            #c_Fa_c = Calpha[kid][:,:nalpha].conj().T @ Fa_c
+            #c_Fb_c = Cbeta[kid][:,:nbeta].conj().T @ Fb_c
+
+            #grad_a = Fa_c - Calpha[kid][:,:nalpha] @ c_Fa_c
+            #grad_b = Fb_c - Cbeta[kid][:,:nbeta] @ c_Fb_c
+
+            #grad_a = Fa_c - epsilon_alpha[kid][None, :nalpha] * Calpha[kid][:,:nalpha]
+            #grad_b = Fb_c - epsilon_beta[kid][None, :nbeta] * Cbeta[kid][:,:nbeta]
+
+            #print('new way', np.linalg.norm(grad_a), np.linalg.norm(grad_b))
+
+            grad_a = form_orbital_gradient(basis, Calpha[kid], nalpha, fock_a[kid], kid)
+            grad_b = form_orbital_gradient(basis, Cbeta[kid], nbeta, fock_b[kid], kid)
+
+            #grad_a = grad_a @ Calpha[kid][:, :nalpha]
+            #grad_b = grad_b @ Cbeta[kid][:, :nbeta]
+
+            #print('old way', np.linalg.norm(grad_a), np.linalg.norm(grad_b))
+
+            error_vector = np.hstack( (error_vector, grad_a.flatten(), grad_b.flatten() ) )
+
+        # extrapolate potential
 
         # norm of orbital gradient
         conv = np.linalg.norm(error_vector)
 
-        # extrapolate solution vector
-        new_solution_vector = inner_diis.update(solution_vector, error_vector)
+        # damp or extrapolate solution vector
+        if scf_iter < diis_start_cycle:
 
-        # reshape solution vector
-        off = 0
-        for kid in range ( len(basis.kpts) ):
-            dim = basis.n_plane_waves_per_k[kid]
-            fock_a[kid] = new_solution_vector[off:off+dim*dim].reshape(fock_a[kid].shape)
-            off += dim*dim
-            fock_b[kid] = new_solution_vector[off:off+dim*dim].reshape(fock_b[kid].shape)
-            off += dim*dim
+            # damping?
+            va = (1.0-damp) * va_old + damp * va
+            vb = (1.0-damp) * vb_old + damp * vb
+
+            fock_a[kid] = form_fock_matrix(basis, kid, v = va + v_ne) + Vnl + exchange_matrix_alpha
+            fock_b[kid] = form_fock_matrix(basis, kid, v = vb + v_ne) + Vnl + exchange_matrix_beta
+        else :
+
+            solution_vector = np.hstack( (va, vb) )
+            new_solution_vector = inner_diis.update(solution_vector, error_vector)
+            va = new_solution_vector[:len(va)]
+            vb = new_solution_vector[len(va):]
+
+            fock_a[kid] = form_fock_matrix(basis, kid, v = va + v_ne) + Vnl + exchange_matrix_alpha
+            fock_b[kid] = form_fock_matrix(basis, kid, v = vb + v_ne) + Vnl + exchange_matrix_beta
+
+
+        # potential in real space
+        va_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
+        va_r.ravel()[flat_idx] = va + v_ne
+        va_r = np.fft.fftn(va_r)
+
+        vb_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
+        vb_r.ravel()[flat_idx] = vb + v_ne
+        vb_r = np.fft.fftn(vb_r)
 
         one_electron_energy = 0.0
         coulomb_energy = 0.0
@@ -861,15 +1106,110 @@ def uks(cell, basis,
         rho_a = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
         rho_b = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
 
-        # diagonalize extrapolated fock matrix
+        # diagonalize fock matrix with extrapolated potential
+        Kij_G = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
+
         for kid in range ( len(basis.kpts) ):
 
-            n = nalpha - 1
-            if scf_iter == 0 and guess_mix == True :
-                n = nalpha
+            def matvec_a(c):
 
-            epsilon_alpha, Calpha[kid] = scipy.linalg.eigh(fock_a[kid], eigvals=(0, n))
-            epsilon_beta, Cbeta[kid] = scipy.linalg.eigh(fock_b[kid], eigvals=(0, (nbeta-1)))
+                # orbital in real space
+                occ = np.zeros(np.prod(grid_shape), dtype=np.complex128)
+                occ[grid_idx_k[kid]] = c
+                occ = occ.reshape(grid_shape)
+                occ = np.fft.fftn(occ) 
+
+                # exchange
+                Ki_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
+                if xc == 'hf':
+                    for j in range(0, nalpha):
+
+                        # Cij(r') = phi_i(r') phi_j*(r')
+                        # Cij(g) = FFT[Cij(r')]
+                        tmp = np.fft.ifftn(occ_alpha[j].conj() * occ)
+                        Cij = tmp.ravel()[flat_idx]
+
+                        # Kij(g) = Cij(g) * FFT[1/|r-r'|]
+                        Kij_G.ravel()[flat_idx] = Cij * inv_g2 #Kij
+
+                        # Kij(r) = FFT^-1[Kij(g)]
+                        Kij_r = np.fft.fftn(Kij_G)
+
+                        # action of K on an occupied orbital, i: 
+                        # Ki(r) = sum_j Kij(r) phi_j(r)
+                        Ki_r += Kij_r * occ_alpha[j]
+
+                    Ki_r *= -4.0 * np.pi / basis.omega
+
+                # action of potential on orbitals in real space, then transform to reciprocal space
+                tmp = va_r * occ + Ki_r # real space, 3d
+                tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
+                tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
+
+                F_c = T[kid] * c + tmp[basis.kg_to_g[kid]] + Vnl @ c
+
+                #print(np.linalg.norm(F_c - fock_a[kid] @ c))
+
+                return F_c
+                #return fock_a[kid] @ c
+
+            def matvec_b(c):
+
+                # orbital in real space
+                occ = np.zeros(np.prod(grid_shape), dtype=np.complex128)
+                occ[grid_idx_k[kid]] = c
+                occ = occ.reshape(grid_shape)
+                occ = np.fft.fftn(occ) 
+
+                # exchange
+                Ki_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
+
+                if xc == 'hf' :
+                    for j in range(0, nbeta):
+
+                        # Cij(r') = phi_i(r') phi_j*(r')
+                        # Cij(g) = FFT[Cij(r')]
+                        tmp = np.fft.ifftn(occ_beta[j].conj() * occ)
+                        Cij = tmp.ravel()[flat_idx]
+
+                        # Kij(g) = Cij(g) * FFT[1/|r-r'|]
+                        Kij_G.ravel()[flat_idx] = Cij * inv_g2 #Kij
+
+                        # Kij(r) = FFT^-1[Kij(g)]
+                        Kij_r = np.fft.fftn(Kij_G)
+
+                        # action of K on an occupied orbital, i: 
+                        # Ki(r) = sum_j Kij(r) phi_j(r)
+                        Ki_r += Kij_r * occ_beta[j]
+
+                    Ki_r *= -4.0 * np.pi / basis.omega
+
+                # action of potential on orbitals in real space, then transform to reciprocal space
+                tmp = vb_r * occ + Ki_r # real space, 3d
+                tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
+                tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
+
+                F_c = T[kid] * c + tmp[basis.kg_to_g[kid]] + Vnl @ c
+
+                #print(np.linalg.norm(F_c - fock_b[kid] @ c))
+
+                return F_c
+                #return fock_b[kid] @ c
+                
+            F_Calpha = LinearOperator((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), matvec=matvec_a, dtype='complex128')
+            F_Cbeta = LinearOperator((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), matvec=matvec_b, dtype='complex128')
+
+            #epsilon_alpha, Calpha[kid] = lobpcg(F_Calpha, Calpha[kid], largest=False, tol=0.1*d_convergence, maxiter=200)
+            #epsilon_beta, Cbeta[kid] = lobpcg(F_Cbeta, Cbeta[kid], largest=False, tol=0.1*d_convergence, maxiter=200)
+
+            epsilon_alpha[kid], Calpha[kid] = scipy.sparse.linalg.eigsh(F_Calpha, k=nalpha+1, which="SA")
+            epsilon_beta[kid], Cbeta[kid] = scipy.sparse.linalg.eigsh(F_Cbeta, k=nbeta+1, which="SA")
+
+            Calpha[kid] = orthonormalize(Calpha[kid])
+            Cbeta[kid] = orthonormalize(Cbeta[kid])
+
+            #epsilon_alpha, Calpha[kid] = scipy.linalg.eigh(fock_a[kid], eigvals=(0, n))
+            #epsilon_beta, Cbeta[kid] = scipy.linalg.eigh(fock_b[kid], eigvals=(0, (nbeta-1)))
 
             #epsilon_alpha, Calpha = np.linalg.eigh(fock_a)
             #epsilon_beta, Cbeta = np.linalg.eigh(fock_b)
@@ -948,33 +1288,37 @@ def uks(cell, basis,
 
         print("    %5i %20.12lf %20.12lf %20.12lf %10.6lf" %  ( scf_iter, new_total_energy, energy_diff, conv, charge ) )
 
-        if ( conv < d_convergence and energy_diff < e_convergence and recompute_exchange) :
-            break
+        if xc != 'hf':
 
-        elif ( conv < d_convergence and energy_diff < e_convergence and not recompute_exchange) :
-
-            if xc != 'hf':
+            if conv < d_convergence and energy_diff < e_convergence :
                 break
 
-            # update exchange matrix for next set of inner iterations
-
-            # TODO: fix for general k
-            print('')
-            print('        ==> recomputing exchange matrix <==')
-            print('')
-            recompute_exchange = True
-            xc_energy, exchange_matrix_alpha = get_exact_exchange_energy(basis, occ_alpha, nalpha, Calpha, exchange_matrix_alpha, recompute_exchange)
-            if nbeta > 0:
-                my_xc_energy, exchange_matrix_beta = get_exact_exchange_energy(basis, occ_beta, nbeta, Cbeta, exchange_matrix_beta, recompute_exchange)
-                xc_energy += my_xc_energy
-            xc_energy -= 0.5 * (nalpha + nbeta) * madelung
-
-            # reset diis ... not sure why this is necessary, but convergence is slow otherwise
-            inner_diis = lib.diis.DIIS()
-            inner_diis.space = diis_dimension
-
         else :
-            recompute_exchange = False
+
+            if (conv < d_convergence and energy_diff < e_convergence and recompute_exchange) :
+                break
+
+            elif (conv < d_convergence and energy_diff < e_convergence and not recompute_exchange or scf_iter == 0):
+
+                # update exchange matrix for next set of inner iterations
+
+                # TODO: fix for general k
+                print('')
+                print('        ==> recomputing exchange matrix <==')
+                print('')
+                recompute_exchange = True
+                xc_energy, exchange_matrix_alpha = get_exact_exchange_energy(basis, occ_alpha, nalpha, Calpha, exchange_matrix_alpha, recompute_exchange)
+                if nbeta > 0:
+                    my_xc_energy, exchange_matrix_beta = get_exact_exchange_energy(basis, occ_beta, nbeta, Cbeta, exchange_matrix_beta, recompute_exchange)
+                    xc_energy += my_xc_energy
+                xc_energy -= 0.5 * (nalpha + nbeta) * madelung
+
+                # reset diis ... not sure why this is necessary, but convergence is slow otherwise
+                inner_diis = lib.diis.DIIS()
+                inner_diis.space = diis_dimension
+
+            else :
+                recompute_exchange = False
 
     if scf_iter == maxiter - 1:
         print('')
@@ -999,170 +1343,4 @@ def uks(cell, basis,
     #assert(np.isclose( np.real(one_electron_energy) + np.real(coulomb_energy) + np.real(xc_energy) + enuc, -9.802901383306) )
 
     return np.real(one_electron_energy) + np.real(coulomb_energy) + np.real(xc_energy) + enuc, Calpha, Cbeta
-
-def uks_energy(cell, basis, Calpha, Cbeta, xc = 'lda'):
-
-    """
-
-    evaluate the uks energy for a given set of MO coefficients
-
-    :param cell: the unit cell
-    :param basis: plane wave basis information
-    :param Calpha: alpha MO coefficients
-    :param Cbeta: beta MO coefficients
-    :param xc: the exchange-correlation functional
-
-    :return total energy
-    """
-
-    if xc != 'lda' and xc != 'pbe' and xc != 'hf' :
-        raise Exception("uks only supports xc = 'lda' and 'hf' for now")
-
-    libxc_x_functional = None
-    libxc_c_functional = None
-
-    if functional_name_dict[xc][0] is not None :
-        libxc_x_functional = pylibxc.LibXCFunctional(functional_name_dict[xc][0], "polarized")
-
-    if functional_name_dict[xc][1] is not None :
-        libxc_c_functional = pylibxc.LibXCFunctional(functional_name_dict[xc][1], "polarized")
-
-    # get nuclear repulsion energy
-    enuc = cell.energy_nuc()
-
-    # coulomb and xc potentials in reciprocal space
-    v_coulomb = np.zeros(len(basis.g), dtype = 'complex128')
-    v_xc_alpha = np.zeros(len(basis.g), dtype = 'complex128')
-    v_xc_beta = np.zeros(len(basis.g), dtype = 'complex128')
-
-    exchange_matrix_alpha = np.zeros((basis.n_plane_waves_per_k[0], basis.n_plane_waves_per_k[0]), dtype='complex128')
-    exchange_matrix_beta = np.zeros((basis.n_plane_waves_per_k[0], basis.n_plane_waves_per_k[0]), dtype='complex128')
-
-    # density in reciprocal space
-    rhog = np.zeros(len(basis.g), dtype = 'complex128')
-
-    # charges
-    valence_charges = cell.atom_charges()
-
-    if basis.use_pseudopotential:
-        for i in range (0,len(valence_charges)):
-            valence_charges[i] = int(basis.gth_params[i].Zion)
-
-    # electron-nucleus potential
-    v_ne = None
-    if not basis.use_pseudopotential:
-        v_ne = get_nuclear_electronic_potential(cell, basis, valence_charges = valence_charges)
-    else :
-        v_ne = get_local_pseudopotential_gth(basis)
-
-    # madelung correction
-    madelung = tools.pbc.madelung(cell, basis.kpts)
-
-    nalpha, nbeta = cell.nelec
-
-    # build density
-    rho = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
-
-    rho_a = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
-    rho_b = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
-
-    for kid in range ( len(basis.kpts) ):
-
-        # density
-        my_rho_a, occ_alpha = get_density(basis, Calpha[kid], nalpha, kid)
-        my_rho_b, occ_beta = get_density(basis, Cbeta[kid], nbeta, kid)
-
-        # density should be non-negative ...
-        rho_a += my_rho_a.clip(min = 0)
-        rho_b += my_rho_b.clip(min = 0)
-
-    # total density
-    rho = rho_a + rho_b
-
-    # coulomb potential
-    tmp = np.fft.ifftn(rho)
-    for myg in range( len(basis.g) ):
-        rhog[myg] = tmp[ get_miller_indices(myg, basis) ]
-
-    v_coulomb = 4.0 * np.pi * np.divide(rhog, basis.g2, out = np.zeros_like(basis.g2), where = basis.g2 != 0.0) # / omega
-
-    occ_alpha = []
-    occ_beta = []
-
-    # exchange-correlation potential
-    if xc != 'hf' :
-
-        v_xc_alpha, v_xc_beta = get_xc_potential(xc, basis, rho_a, rho_b, libxc_x_functional, libxc_c_functional)
-
-    else :
-
-        dum, exchange_matrix_alpha = get_exact_exchange_energy(basis, occ_alpha, nalpha, Calpha)
-        if nbeta > 0:
-            dum, exchange_matrix_beta = get_exact_exchange_energy(basis, occ_beta, nbeta, Cbeta)
-
-    # total potential
-
-    if xc != 'hf' :
-        va = v_coulomb + v_ne + v_xc_alpha
-        vb = v_coulomb + v_ne + v_xc_beta
-    else :
-        va = v_coulomb + v_ne
-        vb = v_coulomb + v_ne
-
-    # accumulate energy
-
-    if xc != 'hf':
-
-        xc_energy = get_xc_energy(xc, basis, rho_a, rho_b, libxc_x_functional, libxc_c_functional)
-
-    else :
-
-        # TODO: fix for general k
-        print()
-        print("uks_energy() only supports xc = 'lda' for now")
-        print()
-        exit()
-        xc_energy, v_xc = get_exact_exchange_energy(basis, occ_alpha, nalpha, Calpha)
-        if nbeta > 0:
-            my_xc_energy, v_xc = get_exact_exchange_energy(basis, occ_beta, nbeta, Cbeta)
-            xc_energy += my_xc_energy
-
-        xc_energy -= 0.5 * (nalpha + nbeta) * madelung
-
-    one_electron_energy = 0.0
-    coulomb_energy = 0.0
-
-    for kid in range ( len(basis.kpts) ):
-
-        # one-electron part of the energy (alpha)
-        one_electron_energy += get_one_electron_energy(basis,
-                                                       Calpha[kid],
-                                                       nalpha,
-                                                       kid,
-                                                       v_ne = v_ne)
-
-        # one-electron part of the energy (beta)
-        one_electron_energy += get_one_electron_energy(basis,
-                                                       Cbeta[kid],
-                                                       nbeta,
-                                                       kid,
-                                                       v_ne = v_ne)
-
-        # coulomb part of the energy: 1/2 J
-        coulomb_energy += get_coulomb_energy(basis, Calpha[kid], nalpha, kid, v_coulomb)
-
-        # coulomb part of the energy: 1/2 J
-        coulomb_energy += get_coulomb_energy(basis, Cbeta[kid], nbeta, kid, v_coulomb)
-
-    print('    ==> energy components <==')
-    print('')
-    print('    nuclear repulsion energy: %20.12lf' % ( enuc ) )
-    print('    one-electron energy:      %20.12lf' % ( np.real(one_electron_energy) ) )
-    print('    coulomb energy:           %20.12lf' % ( np.real(coulomb_energy) ) )
-    print('    xc energy:                %20.12lf' % ( np.real(xc_energy) ) )
-    print('')
-    print('    total energy:             %20.12lf' % ( np.real(one_electron_energy) + np.real(coulomb_energy) + np.real(xc_energy) + enuc ) )
-    print('')
-
-    return np.real(one_electron_energy) + np.real(coulomb_energy) + np.real(xc_energy) + enuc
 

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -837,14 +837,8 @@ def uks(cell, basis,
     # get nuclear repulsion energy
     enuc = cell.energy_nuc()
 
-    # coulomb and xc potentials in reciprocal space
-    v_coulomb = np.zeros(len(basis.g), dtype = 'complex128')
-    v_xc_alpha = np.zeros(len(basis.g), dtype = 'complex128')
-    v_xc_beta = np.zeros(len(basis.g), dtype = 'complex128')
-
     # density in reciprocal space
     rhog = np.zeros(len(basis.g), dtype = 'complex128')
-    inner_rhog = np.zeros(len(basis.g), dtype = 'complex128')
 
     # charges
     valence_charges = cell.atom_charges()
@@ -994,33 +988,30 @@ def uks(cell, basis,
 
     v_alpha = 0 * v_ne
     v_beta = 0 * v_ne
-    v_alpha_old = 0 * v_ne
-    v_beta_old = 0 * v_ne
-
-    rho_alpha = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
-    rho_beta = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
-    rho_alpha_old = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
-    rho_beta_old = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
 
     # jellium guess
     rho_alpha = nalpha / basis.omega * np.ones(basis.real_space_grid_dim, dtype = 'float64')
     rho_beta = nbeta / basis.omega * np.ones(basis.real_space_grid_dim, dtype = 'float64')
+    rho_alpha_old = rho_alpha.copy()
+    rho_beta_old = rho_beta.copy()
 
-    # rebuild potentials
+    # potentials
     rho = rho_alpha + rho_beta
 
     # coulomb potential
     tmp = np.fft.ifftn(rho)
     for myg in range( len(basis.g) ):
-        inner_rhog[myg] = tmp[ get_miller_indices(myg, basis) ]
+        rhog[myg] = tmp[ get_miller_indices(myg, basis) ]
 
-    v_coulomb = 4.0 * np.pi * inner_rhog * basis.inv_g2
+    v_coulomb = 4.0 * np.pi * rhog * basis.inv_g2
 
     # jellium ... but only true in the thermodynamic limit
     if jellium:
         v_coulomb *= 0.0
 
     # exchange-correlation potential
+    v_xc_alpha = np.zeros(len(basis.g), dtype = 'complex128')
+    v_xc_beta = np.zeros(len(basis.g), dtype = 'complex128')
     if xc != 'hf' :
 
         v_xc_alpha, v_xc_beta = get_xc_potential(xc, basis, rho_alpha, rho_beta, libxc_x_functional, libxc_c_functional)
@@ -1036,9 +1027,6 @@ def uks(cell, basis,
 
         v_alpha = v_coulomb + v_xc_alpha
         v_beta = v_coulomb + v_xc_beta
-
-        v_alpha_old = v_alpha
-        v_beta_old = v_beta
 
         # potential in real space
         v_alpha_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
@@ -1122,9 +1110,9 @@ def uks(cell, basis,
         # coulomb potential
         tmp = np.fft.ifftn(rho)
         for myg in range( len(basis.g) ):
-            inner_rhog[myg] = tmp[ get_miller_indices(myg, basis) ]
+            rhog[myg] = tmp[ get_miller_indices(myg, basis) ]
 
-        v_coulomb = 4.0 * np.pi * inner_rhog * basis.inv_g2
+        v_coulomb = 4.0 * np.pi * rhog * basis.inv_g2
 
         # jellium ... but only true in the thermodynamic limit
         if jellium:
@@ -1320,9 +1308,9 @@ def uks(cell, basis,
         # coulomb potential
         tmp = np.fft.ifftn(rho)
         for myg in range( len(basis.g) ):
-            inner_rhog[myg] = tmp[ get_miller_indices(myg, basis) ]
+            rhog[myg] = tmp[ get_miller_indices(myg, basis) ]
 
-        v_coulomb = 4.0 * np.pi * inner_rhog * basis.inv_g2
+        v_coulomb = 4.0 * np.pi * rhog * basis.inv_g2
 
         # jellium ... but only true in the thermodynamic limit
         if jellium:

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -468,7 +468,8 @@ def get_nonlocal_pp_energy(basis, C, N, kid, occupation_numbers):
 
     return nonlocal_pp_energy
 
-def fock_on_orbitals(basis, kid, ne, nmo, phi_r, C, T, v_r, Vnl, xc, occupation_numbers, adiabatic_exchange_lambda):
+# TODO: use real-space representation of non-local pseudopotential here
+def fock_on_orbitals(basis, kid, ne, nmo, phi_r, C, T, v_r, xc, occupation_numbers, adiabatic_exchange_lambda):
     """
     evaluate action of fock matrix on orbitals and build ace operator
 
@@ -480,7 +481,6 @@ def fock_on_orbitals(basis, kid, ne, nmo, phi_r, C, T, v_r, Vnl, xc, occupation_
     :param C: orbitals, in reciprocal space
     :param T: diagonal of the kinetic energy matrix, in reciprocal space
     :param v_r: the potential (coulomb + local pseudopotential + xc), in real space
-    :param Vnl: matrix representation of non-local pseudopotential, in reciprocal space
     :param xc: the exchange-correlation functional
     :param occupation_numbers: a list of occupation numbers (0, 1, or fermi-dirac for smearing)
     :param adiabatic_exchange_lambda: a scaling factor on the interval [0, 1] for ramping up exchange
@@ -602,7 +602,10 @@ def fock_on_orbitals_using_ace(basis, kid, ne, nmo, phi_r, c, T, v_r, Vnl, xc, K
     tmp_vphi = tmp_vphi.reshape(c.shape) # for lobpcg
 
     #F_c = T[kid] * c + tmp + Vnl @ c # eigsh
-    F_c = T[kid][:, None] * c + tmp_vphi + Vnl @ c # lobpcg
+    F_c = T[kid][:, None] * c + tmp_vphi  # lobpcg
+
+    if Vnl is not None:
+        F_c += Vnl @ c # lobpcg
 
     if xc == 'hf':
         if ace_exchange :
@@ -849,7 +852,8 @@ def uks(cell, basis,
         jellium = False,
         jellium_ne = 2,
         maxiter=500,
-        kBT=None):
+        kBT=None,
+        print_level = 1):
         #kerker_q0=None,
         #kerker_alpha=0.05):
 
@@ -873,13 +877,14 @@ def uks(cell, basis,
     # :param kerker_q0: screening length for kerker preconditioning. if None, chosen to be the Fermi wavevector for jellium
     # :param kerker_alpha: kerker mixing parameter. default should be good for metallic systems
 
-    print('')
-    print('    ************************************************')
-    print('    *                                              *')
-    print('    *                Plane-wave UKS                *')
-    print('    *                                              *')
-    print('    ************************************************')
-    print('')
+    if print_level > 0:
+        print('')
+        print('    ************************************************')
+        print('    *                                              *')
+        print('    *                Plane-wave UKS                *')
+        print('    *                                              *')
+        print('    ************************************************')
+        print('')
 
     if len(basis.kpts) > 1 and kBT is not None:
         raise Exception("smearing only works for the gamma point for now")
@@ -945,45 +950,41 @@ def uks(cell, basis,
         nmo_alpha *= 2
         nmo_beta *= 2
 
-    print("")
+    if print_level > 0:
+        print("")
     if jellium:
         rs = (3 * basis.omega / ( 4.0 * np.pi * (nalpha + nbeta)))**(1.0/3.0)
-        print('    Wigner-Seitz radius (rs)                     %20.12f' % (rs))
+        if print_level > 0:
+            print('    Wigner-Seitz radius (rs)                     %20.12f' % (rs))
     if kBT is not None:
-        print('    kBT for smearing (eV)                        %20.12f' % (kBT * 27.21138602))
-    print('    exchange functional:                         %20s' % ( functional_name_dict[xc][0] ) )
-    print('    correlation functional:                      %20s' % ( functional_name_dict[xc][1] ) )
-    print('    e_convergence:                               %20.2e' % ( e_convergence ) )
-    print('    d_convergence:                               %20.2e' % ( d_convergence ) )
-    print('    no. k-points:                                %20i' % ( len(basis.kpts) ) )
-    print('    KE cutoff (eV)                               %20.2f' % ( basis.ke_cutoff * 27.21138602 ) )
-    print('    no. basis functions (orbitals, gamma point): %20i' % ( basis.n_plane_waves_per_k[0] ) )
-    print('    no. basis functions (density):               %20i' % ( len(basis.g) ) )
-    print('    total_charge:                                %20i' % ( total_charge ) )
-    print('    no. alpha occupied bands:                    %20i' % ( nalpha ) )
-    print('    no. beta occupied bands:                     %20i' % ( nbeta ) )
-    print('    no. total alpha bands:                       %20i' % ( nmo_alpha ) )
-    print('    no. total beta bands:                        %20i' % ( nmo_beta ) )
-    print('    break spin symmetry:                         %20s' % ( "yes" if guess_mix is True else "no" ) )
-    print('    no. diis vectors:                            %20i' % ( diis_dimension ) )
-    #if kerker_q0 is not None:
-    #    print('    kerker screening length                      %20.2f' % ( kerker_q0) )
-    #print('    kerker mixing parameter                      %20.2f' % ( kerker_alpha) )
+        if print_level > 0:
+            print('    kBT for smearing (eV)                        %20.12f' % (kBT * 27.21138602))
+    if print_level > 0:
+        print('    exchange functional:                         %20s' % ( functional_name_dict[xc][0] ) )
+        print('    correlation functional:                      %20s' % ( functional_name_dict[xc][1] ) )
+        print('    e_convergence:                               %20.2e' % ( e_convergence ) )
+        print('    d_convergence:                               %20.2e' % ( d_convergence ) )
+        print('    no. k-points:                                %20i' % ( len(basis.kpts) ) )
+        print('    KE cutoff (eV)                               %20.2f' % ( basis.ke_cutoff * 27.21138602 ) )
+        print('    no. basis functions (orbitals, gamma point): %20i' % ( basis.n_plane_waves_per_k[0] ) )
+        print('    no. basis functions (density):               %20i' % ( len(basis.g) ) )
+        print('    total_charge:                                %20i' % ( total_charge ) )
+        print('    no. alpha occupied bands:                    %20i' % ( nalpha ) )
+        print('    no. beta occupied bands:                     %20i' % ( nbeta ) )
+        print('    no. total alpha bands:                       %20i' % ( nmo_alpha ) )
+        print('    no. total beta bands:                        %20i' % ( nmo_beta ) )
+        print('    break spin symmetry:                         %20s' % ( "yes" if guess_mix is True else "no" ) )
+        print('    no. diis vectors:                            %20i' % ( diis_dimension ) )
+        #if kerker_q0 is not None:
+        #    print('    kerker screening length                      %20.2f' % ( kerker_q0) )
+        #print('    kerker mixing parameter                      %20.2f' % ( kerker_alpha) )
 
     if guess_mix :
-        print("")
-        print("    ==> WARNING <==")
-        print("")
-        print("        guess_mix = True is not working and is currently disabled")
-
-    print("")
-    print("    ==> Begin UKS Iterations <==")
-    print("")
-
-    if jellium:
-        print("    %5s %20s %20s %20s %10s %20s %20s %20s %20s %20s" % ('iter', 'energy', '|dE|', '||[F, D]||', 'Nelec', '||Ca - Cb||', 'kinetic', 'coulomb', 'exchange', 'madelung'))
-    else :
-        print("    %5s %20s %20s %20s %10s" % ('iter', 'energy', '|dE|', '||[F, D]||', 'Nelec'))
+        if print_level > 0:
+            print("")
+            print("    ==> WARNING <==")
+            print("")
+            print("        guess_mix = True is not working and is currently disabled")
 
     old_total_energy = 0.0
 
@@ -1038,23 +1039,46 @@ def uks(cell, basis,
         # jellium orbital guess, plus some noise
         if jellium:
 
-            #lowest_energy_T_index = np.argsort(T[kid])[:nalpha]
-            #epsilon_alpha[kid] = T[kid][lowest_energy_T_index]
-            #Calpha[kid] = np.zeros((len(T[kid]), nalpha), dtype=np.complex128)
-            #for orb_idx, pw_idx in enumerate(lowest_energy_T_index):
-            #    Calpha[kid][pw_idx, orb_idx] = 1.0
+            lowest_energy_T_index = np.argsort(T[kid])[:nalpha]
+            epsilon_alpha[kid] = T[kid][lowest_energy_T_index]
+            Calpha[kid] = np.zeros((len(T[kid]), nalpha), dtype=np.complex128)
+            for orb_idx, pw_idx in enumerate(lowest_energy_T_index):
+                Calpha[kid][pw_idx, orb_idx] = 1.0
 
-            eps_a, ca = np.linalg.eigh(np.diag(T[kid]))
-            epsilon_alpha[kid], Calpha[kid] = eps_a[:nmo_alpha], ca[:, :nmo_alpha]
-            # mix in other plane waves? 
-            #for j in range (0, nmo_alpha):
-            #    Calpha[kid][:, j] += 1e-3 * ca[:, nmo_alpha + j] 
+            #eps_a, ca = np.linalg.eigh(np.diag(T[kid]))
+            #epsilon_alpha[kid], Calpha[kid] = eps_a[:nmo_alpha], ca[:, :nmo_alpha]
 
             #Calpha[kid] += np.random.rand(basis.n_plane_waves_per_k[kid], nmo_alpha) * 1e-3
             Calpha[kid] = orthonormalize(Calpha[kid])
             Cbeta[kid] = Calpha[kid].copy()
-            #one_electron_energy = np.sum(np.einsum('pi,p->i', np.abs(Calpha[kid][:,:nalpha])**2, T[kid]))
-            #one_electron_energy += np.sum(np.einsum('pi,p->i', np.abs(Cbeta[kid][:,:nbeta])**2, T[kid]))
+
+            # update density
+            my_rho_alpha, phi_alpha = get_density(basis, Calpha[kid], nalpha, nmo_alpha, kid, occ_num_alpha)
+            my_rho_beta, phi_beta = get_density(basis, Cbeta[kid], nbeta, nmo_beta, kid, occ_num_beta)
+
+            # density should be non-negative ...
+            rho_alpha = my_rho_alpha.clip(min = 0).real
+            rho_beta = my_rho_beta.clip(min = 0).real
+
+            # kinetic energy part of the one-electron energy
+            one_electron_energy = np.sum(np.einsum('pi,p->i', np.abs(Calpha[kid][:,:nmo_alpha])**2 * occ_num_alpha, T[kid]))
+            one_electron_energy += np.sum(np.einsum('pi,p->i', np.abs(Cbeta[kid][:,:nmo_beta])**2 * occ_num_beta, T[kid]))
+
+            # exact exchange energy
+            xc_energy = get_exact_exchange_energy(basis, phi_alpha, nmo_alpha, Calpha, occ_num_alpha)
+            if nbeta > 0:
+                my_xc_energy = get_exact_exchange_energy(basis, phi_beta, nmo_beta, Cbeta, occ_num_beta)
+                xc_energy += my_xc_energy
+            energy = one_electron_energy + xc_energy - 0.5 * (nalpha + nbeta) * madelung
+
+            if print_level > 0:
+                print()
+                print("    %20s %20s %20s %20s" % ('energy', 'kinetic', 'exchange', 'madelung'))
+                print("    %20.12lf %20.12lf %20.12lf %20.12f" %  (energy.real, one_electron_energy.real, xc_energy.real, -0.5 * (nalpha + nbeta) * madelung))
+                print()
+                exit()
+            print("%5i\t%6.2f\t%20.12e\t%20.12e\t%20.12e\t%20.12e\t%20.12e" %  (nalpha + nbeta, rs, basis.omega, energy.real, one_electron_energy.real, xc_energy.real, -0.5 * (nalpha + nbeta) * madelung))
+            return energy.real, Calpha, Cbeta
 
     # initialize phi_alpha and phi_beta arrays ... won't work for kpts > 0
     rho_alpha, phi_alpha = get_density(basis, Calpha[0], nalpha, nmo_alpha, kid, occ_num_alpha)
@@ -1072,6 +1096,19 @@ def uks(cell, basis,
     diis.space = diis_dimension
 
     adiabatic_exchange_lambda = 0.0
+
+    if print_level > 0:
+        print("")
+        print("    ==> Begin UKS Iterations <==")
+        print("")
+
+    if jellium:
+        if print_level > 0:
+            print("    %5s %20s %20s %20s %10s %20s %20s %20s %20s %20s" % ('iter', 'energy', '|dE|', '||[F, D]||', 'Nelec', '||Ca - Cb||', 'kinetic', 'coulomb', 'exchange', 'madelung'))
+    else :
+        if print_level > 0:
+            print("    %5s %20s %20s %20s %10s" % ('iter', 'energy', '|dE|', '||[F, D]||', 'Nelec'))
+
     for i in range (0, 1):
         adiabatic_exchange_lambda += 1
 
@@ -1102,18 +1139,8 @@ def uks(cell, basis,
             error_vector = np.zeros(0)
             for kid in range( len(basis.kpts) ):
 
-                # TODO: don't store non-local pseudopotential in the planewave basis
-                Vnl = get_nonlocal_pseudopotential_matrix_elements(basis, kid, use_legendre = basis.nl_pp_use_legendre)
-                Vnl = Vnl + Vnl.conj().T
-                diag = np.diag(Vnl)
-                np.fill_diagonal(Vnl, 0.5 * diag)
-
-                # jellium
-                if jellium:
-                    Vnl *= 0.0
-
-                Fa_c, Ki_alpha[kid], exchange_alpha = fock_on_orbitals(basis, kid, nalpha, nmo_alpha, phi_alpha, Calpha, T, v_alpha_r, Vnl, xc, occ_num_alpha, adiabatic_exchange_lambda)
-                Fb_c, Ki_beta[kid], exchange_beta = fock_on_orbitals(basis, kid, nbeta, nmo_beta, phi_beta, Cbeta, T, v_beta_r, Vnl, xc, occ_num_beta, adiabatic_exchange_lambda)
+                Fa_c, Ki_alpha[kid], exchange_alpha = fock_on_orbitals(basis, kid, nalpha, nmo_alpha, phi_alpha, Calpha, T, v_alpha_r, xc, occ_num_alpha, adiabatic_exchange_lambda)
+                Fb_c, Ki_beta[kid], exchange_beta = fock_on_orbitals(basis, kid, nbeta, nmo_beta, phi_beta, Cbeta, T, v_beta_r, xc, occ_num_beta, adiabatic_exchange_lambda)
 
                 if xc == 'hf':
 
@@ -1123,8 +1150,14 @@ def uks(cell, basis,
                     Fa_c += exchange_alpha
                     Fb_c += exchange_beta
                 
-                Fa_c += Vnl @ Calpha[kid][:, :nmo_alpha]
-                Fb_c += Vnl @ Cbeta[kid][:, :nmo_beta]
+                if not jellium:
+                    # TODO: don't store non-local pseudopotential in the planewave basis
+                    Vnl = get_nonlocal_pseudopotential_matrix_elements(basis, kid, use_legendre = basis.nl_pp_use_legendre)
+                    Vnl = Vnl + Vnl.conj().T
+                    diag = np.diag(Vnl)
+                    np.fill_diagonal(Vnl, 0.5 * diag)
+                    Fa_c += Vnl @ Calpha[kid][:, :nmo_alpha]
+                    Fb_c += Vnl @ Cbeta[kid][:, :nmo_beta]
 
                 #grad_a = Fa_c - epsilon_alpha[kid][np.newaxis, :nmo_alpha] * Calpha[kid][:,:nmo_alpha]
                 #grad_b = Fb_c - epsilon_beta[kid][np.newaxis, :nmo_beta] * Cbeta[kid][:,:nmo_beta]
@@ -1161,14 +1194,14 @@ def uks(cell, basis,
 
             for kid in range ( len(basis.kpts) ):
 
-                Vnl = get_nonlocal_pseudopotential_matrix_elements(basis, kid, use_legendre = basis.nl_pp_use_legendre)
-                Vnl = Vnl + Vnl.conj().T
-                diag = np.diag(Vnl)
-                np.fill_diagonal(Vnl, 0.5 * diag)
-
                 # jellium
                 if jellium:
-                    Vnl *= 0.0
+                    Vnl = None
+                else:
+                    Vnl = get_nonlocal_pseudopotential_matrix_elements(basis, kid, use_legendre = basis.nl_pp_use_legendre)
+                    Vnl = Vnl + Vnl.conj().T
+                    diag = np.diag(Vnl)
+                    np.fill_diagonal(Vnl, 0.5 * diag)
 
                 def lobpcg_alpha(c):
                     return fock_on_orbitals_using_ace(basis, kid, nalpha, nmo_alpha, phi_alpha, c, T, v_alpha_r, Vnl, xc, Ki_alpha[kid], B_alpha_ace[kid], ace_exchange, occ_num_alpha, adiabatic_exchange_lambda)
@@ -1194,14 +1227,9 @@ def uks(cell, basis,
                 # update occupation numbers for smearing
                 mu_alpha = find_chemical_potential(nalpha, epsilon_alpha[kid], kBT = kBT)
                 mu_beta = find_chemical_potential(nbeta, epsilon_beta[kid], kBT = kBT)
-                #print('optimized mu (alpha)', mu_alpha)
-                #print('optimized mu (beta)', mu_beta)
 
                 occ_num_alpha = fermi_dirac(nalpha, epsilon_alpha[kid], mu_alpha, kBT = kBT)
                 occ_num_beta = fermi_dirac(nbeta, epsilon_beta[kid], mu_beta, kBT = kBT)
-                #print(occ_num_alpha)
-                #print('alpha', occ_num_alpha)
-                #print('beta ', occ_num_beta)
 
                 # break spin symmetry? # TODO this is broken, which probably indicates there is some other problem ...
                 #if guess_mix and scf_iter == 0:
@@ -1287,39 +1315,49 @@ def uks(cell, basis,
             charge = ( basis.omega / ( basis.real_space_grid_dim[0] * basis.real_space_grid_dim[1] * basis.real_space_grid_dim[2] ) ) * np.sum(np.absolute(rho_alpha + rho_beta))
 
             if jellium:
-                print("    %5i %20.12lf %20.12lf %20.12lf %10.6lf %20.12f %20.12f %20.12f %20.12f %20.12f" %  ( scf_iter, new_total_energy, energy_diff, conv, charge, np.linalg.norm(Calpha[kid] - Cbeta[kid]), np.real(one_electron_energy), np.real(coulomb_energy), np.real(xc_energy), -0.5 * (nalpha + nbeta) * madelung))
+                if print_level > 0:
+                    print("    %5i %20.12lf %20.12lf %20.12lf %10.6lf %20.12f %20.12f %20.12f %20.12f %20.12f" %  ( scf_iter, new_total_energy, energy_diff, conv, charge, np.linalg.norm(Calpha[kid] - Cbeta[kid]), np.real(one_electron_energy), np.real(coulomb_energy), np.real(xc_energy), -0.5 * (nalpha + nbeta) * madelung))
             else :
-                print("    %5i %20.12lf %20.12lf %20.12lf %10.6lf" %  ( scf_iter, new_total_energy, energy_diff, conv, charge))
+                if print_level > 0:
+                    print("    %5i %20.12lf %20.12lf %20.12lf %10.6lf" %  ( scf_iter, new_total_energy, energy_diff, conv, charge))
 
             if conv < d_convergence and energy_diff < e_convergence:
                 break
 
         if scf_iter == maxiter - 1:
-            print('')
-            print('    UKS iterations did not converge.')
-            print('')
+            if print_level > 0:
+                print('')
+                print('    UKS iterations did not converge.')
+                print('')
         else:
-            print('')
-            print('    UKS iterations converged!')
-            print('')
+            if print_level > 0:
+                print('')
+                print('    UKS iterations converged!')
+                print('')
 
     # end of adiabatic increase in exchange 
 
 
-    print('    ==> energy components <==')
-    print('')
-    print('    nuclear repulsion energy: %20.12lf' % ( enuc ) )
-    print('    one-electron energy:      %20.12lf' % ( np.real(one_electron_energy) ) )
-    print('    coulomb energy:           %20.12lf' % ( np.real(coulomb_energy) ) )
-    print('    xc energy:                %20.12lf' % ( np.real(xc_energy) ) )
+    if print_level > 0:
+        print('    ==> energy components <==')
+        print('')
+        print('    nuclear repulsion energy: %20.12lf' % ( enuc ) )
+        print('    one-electron energy:      %20.12lf' % ( np.real(one_electron_energy) ) )
+        print('    coulomb energy:           %20.12lf' % ( np.real(coulomb_energy) ) )
+        print('    xc energy:                %20.12lf' % ( np.real(xc_energy) ) )
     if jellium:
-        print('    Madelung:                 %20.12lf' % ( -0.5 * (nalpha + nbeta) * madelung) )
-    print('')
+        if print_level > 0:
+            print('    Madelung:                 %20.12lf' % ( -0.5 * (nalpha + nbeta) * madelung) )
+    if print_level > 0:
+        print('')
     if jellium:
-        print('    total energy:             %20.12lf' % ( np.real(one_electron_energy) + np.real(coulomb_energy) + np.real(xc_energy) + enuc -0.5 * (nalpha + nbeta) * madelung ) )
+        if print_level > 0:
+            print('    total energy:             %20.12lf' % ( np.real(one_electron_energy) + np.real(coulomb_energy) + np.real(xc_energy) + enuc -0.5 * (nalpha + nbeta) * madelung ) )
     else :
-        print('    total energy:             %20.12lf' % ( np.real(one_electron_energy) + np.real(coulomb_energy) + np.real(xc_energy) + enuc ) )
-    print('')
+        if print_level > 0:
+            print('    total energy:             %20.12lf' % ( np.real(one_electron_energy) + np.real(coulomb_energy) + np.real(xc_energy) + enuc ) )
+    if print_level > 0:
+        print('')
 
     return new_total_energy, Calpha, Cbeta
 

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -809,7 +809,7 @@ def uks(cell, basis,
         damping_factor = 0.5
 
     # diis 
-    diis_dimension = 8
+    diis_dimension = 6
     diis_start_cycle = 4
 
     print("")
@@ -1036,32 +1036,19 @@ def uks(cell, basis,
 
                 Fb_c[:,i] = T[kid] * Cbeta[kid][:, i] + tmp[basis.kg_to_g[kid]]
 
-            fock_a[kid] = form_fock_matrix(basis, kid, v = va + v_ne) + Vnl + exchange_matrix_alpha
-            fock_b[kid] = form_fock_matrix(basis, kid, v = vb + v_ne) + Vnl + exchange_matrix_beta
-
-            Fa_c = fock_a[kid] @ Calpha[kid][:, :nalpha]
-            Fb_c = fock_b[kid] @ Cbeta[kid][:, :nbeta]
-
-            #Fa_c += Vnl @ Calpha[kid][:, :nalpha]
-            #Fb_c += Vnl @ Cbeta[kid][:, :nbeta]
-
-            #c_Fa_c = Calpha[kid][:,:nalpha].conj().T @ Fa_c
-            #c_Fb_c = Cbeta[kid][:,:nbeta].conj().T @ Fb_c
-
-            #grad_a = Fa_c - Calpha[kid][:,:nalpha] @ c_Fa_c
-            #grad_b = Fb_c - Cbeta[kid][:,:nbeta] @ c_Fb_c
-
-            #grad_a = Fa_c - epsilon_alpha[kid][None, :nalpha] * Calpha[kid][:,:nalpha]
-            #grad_b = Fb_c - epsilon_beta[kid][None, :nbeta] * Cbeta[kid][:,:nbeta]
-
+            Fa_c += Vnl @ Calpha[kid][:, :nalpha]
+            Fb_c += Vnl @ Cbeta[kid][:, :nbeta]
+            grad_a = Fa_c - epsilon_alpha[kid][np.newaxis, :nalpha] * Calpha[kid][:,:nalpha]
+            grad_b = Fb_c - epsilon_beta[kid][np.newaxis, :nbeta] * Cbeta[kid][:,:nbeta]
             #print('new way', np.linalg.norm(grad_a), np.linalg.norm(grad_b))
 
-            grad_a = form_orbital_gradient(basis, Calpha[kid], nalpha, fock_a[kid], kid)
-            grad_b = form_orbital_gradient(basis, Cbeta[kid], nbeta, fock_b[kid], kid)
-
-            #grad_a = grad_a @ Calpha[kid][:, :nalpha]
-            #grad_b = grad_b @ Cbeta[kid][:, :nbeta]
-
+            # orbital gradient from [D, F] with the full fock and density matrices
+            #fock_a[kid] = form_fock_matrix(basis, kid, v = va + v_ne) + Vnl + exchange_matrix_alpha
+            #fock_b[kid] = form_fock_matrix(basis, kid, v = vb + v_ne) + Vnl + exchange_matrix_beta
+            #Fa_c = fock_a[kid] @ Calpha[kid][:, :nalpha]
+            #Fb_c = fock_b[kid] @ Cbeta[kid][:, :nbeta]
+            #grad_a = form_orbital_gradient(basis, Calpha[kid], nalpha, fock_a[kid], kid)
+            #grad_b = form_orbital_gradient(basis, Cbeta[kid], nbeta, fock_b[kid], kid)
             #print('old way', np.linalg.norm(grad_a), np.linalg.norm(grad_b))
 
             error_vector = np.hstack( (error_vector, grad_a.flatten(), grad_b.flatten() ) )
@@ -1078,8 +1065,6 @@ def uks(cell, basis,
             va = (1.0-damp) * va_old + damp * va
             vb = (1.0-damp) * vb_old + damp * vb
 
-            fock_a[kid] = form_fock_matrix(basis, kid, v = va + v_ne) + Vnl + exchange_matrix_alpha
-            fock_b[kid] = form_fock_matrix(basis, kid, v = vb + v_ne) + Vnl + exchange_matrix_beta
         else :
 
             solution_vector = np.hstack( (va, vb) )
@@ -1087,9 +1072,8 @@ def uks(cell, basis,
             va = new_solution_vector[:len(va)]
             vb = new_solution_vector[len(va):]
 
-            fock_a[kid] = form_fock_matrix(basis, kid, v = va + v_ne) + Vnl + exchange_matrix_alpha
-            fock_b[kid] = form_fock_matrix(basis, kid, v = vb + v_ne) + Vnl + exchange_matrix_beta
-
+        #fock_a[kid] = form_fock_matrix(basis, kid, v = va + v_ne) + Vnl + exchange_matrix_alpha
+        #fock_b[kid] = form_fock_matrix(basis, kid, v = vb + v_ne) + Vnl + exchange_matrix_beta
 
         # potential in real space
         va_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
@@ -1111,49 +1095,18 @@ def uks(cell, basis,
 
         for kid in range ( len(basis.kpts) ):
 
-            def matvec_a(c):
+            def apply_fock_operator_to_orbital(c):
+                """
+                apply fock operator to an orbital. note that the function depends on 
+                some parameters not passed in as argumnets
 
-                # orbital in real space
-                occ = np.zeros(np.prod(grid_shape), dtype=np.complex128)
-                occ[grid_idx_k[kid]] = c
-                occ = occ.reshape(grid_shape)
-                occ = np.fft.fftn(occ) 
+                :param c: orbital in reciprococal space
+                :return F @ c: action of fock operator on the orbital in reciprococal space
 
-                # exchange
-                Ki_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
-                if xc == 'hf':
-                    for j in range(0, nalpha):
-
-                        # Cij(r') = phi_i(r') phi_j*(r')
-                        # Cij(g) = FFT[Cij(r')]
-                        tmp = np.fft.ifftn(occ_alpha[j].conj() * occ)
-                        Cij = tmp.ravel()[flat_idx]
-
-                        # Kij(g) = Cij(g) * FFT[1/|r-r'|]
-                        Kij_G.ravel()[flat_idx] = Cij * inv_g2 #Kij
-
-                        # Kij(r) = FFT^-1[Kij(g)]
-                        Kij_r = np.fft.fftn(Kij_G)
-
-                        # action of K on an occupied orbital, i: 
-                        # Ki(r) = sum_j Kij(r) phi_j(r)
-                        Ki_r += Kij_r * occ_alpha[j]
-
-                    Ki_r *= -4.0 * np.pi / basis.omega
-
-                # action of potential on orbitals in real space, then transform to reciprocal space
-                tmp = va_r * occ + Ki_r # real space, 3d
-                tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
-                tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
-
-                F_c = T[kid] * c + tmp[basis.kg_to_g[kid]] + Vnl @ c
-
-                #print(np.linalg.norm(F_c - fock_a[kid] @ c))
-
-                return F_c
-                #return fock_a[kid] @ c
-
-            def matvec_b(c):
+                :implicit parameter my_N: the number of electrons of the same spin as orbital c 
+                :implicit parameter occ_list: a list of occupied orbitals in real space with the same spin as orbital c
+                :implicit parameter my_v_r: the potential in real space experienced by orbital c (excluding exchange)
+                """
 
                 # orbital in real space
                 occ = np.zeros(np.prod(grid_shape), dtype=np.complex128)
@@ -1165,11 +1118,11 @@ def uks(cell, basis,
                 Ki_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
 
                 if xc == 'hf' :
-                    for j in range(0, nbeta):
+                    for j in range(0, my_N):
 
                         # Cij(r') = phi_i(r') phi_j*(r')
                         # Cij(g) = FFT[Cij(r')]
-                        tmp = np.fft.ifftn(occ_beta[j].conj() * occ)
+                        tmp = np.fft.ifftn(occ_list[j].conj() * occ)
                         Cij = tmp.ravel()[flat_idx]
 
                         # Kij(g) = Cij(g) * FFT[1/|r-r'|]
@@ -1180,31 +1133,39 @@ def uks(cell, basis,
 
                         # action of K on an occupied orbital, i: 
                         # Ki(r) = sum_j Kij(r) phi_j(r)
-                        Ki_r += Kij_r * occ_beta[j]
+                        Ki_r += Kij_r * occ_list[j]
 
                     Ki_r *= -4.0 * np.pi / basis.omega
 
                 # action of potential on orbitals in real space, then transform to reciprocal space
-                tmp = vb_r * occ + Ki_r # real space, 3d
+                tmp = my_v_r * occ + Ki_r # real space, 3d
                 tmp = np.fft.ifftn(tmp) # reciprocal space, 3d
                 tmp = tmp.ravel()[flat_idx] # reciprocal space, large flattened basis
 
                 F_c = T[kid] * c + tmp[basis.kg_to_g[kid]] + Vnl @ c
 
-                #print(np.linalg.norm(F_c - fock_b[kid] @ c))
+                #assert np.allclose(F_c, fock_a[kid] @ c)
+                #print(np.linalg.norm(F_c - fock_a[kid] @ c))
 
                 return F_c
-                #return fock_b[kid] @ c
-                
-            F_Calpha = LinearOperator((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), matvec=matvec_a, dtype='complex128')
-            F_Cbeta = LinearOperator((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), matvec=matvec_b, dtype='complex128')
+                #return fock_a[kid] @ c
+
+            F_C = LinearOperator((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), matvec=apply_fock_operator_to_orbital, dtype='complex128')
 
             #epsilon_alpha, Calpha[kid] = lobpcg(F_Calpha, Calpha[kid], largest=False, tol=0.1*d_convergence, maxiter=200)
             #epsilon_beta, Cbeta[kid] = lobpcg(F_Cbeta, Cbeta[kid], largest=False, tol=0.1*d_convergence, maxiter=200)
 
-            epsilon_alpha[kid], Calpha[kid] = scipy.sparse.linalg.eigsh(F_Calpha, k=nalpha+1, which="SA")
-            epsilon_beta[kid], Cbeta[kid] = scipy.sparse.linalg.eigsh(F_Cbeta, k=nbeta+1, which="SA")
+            my_N = nalpha
+            occ_list = occ_alpha.copy()
+            my_v_r = va_r.copy()
+            epsilon_alpha[kid], Calpha[kid] = scipy.sparse.linalg.eigsh(F_C, k=nalpha+1, which="SA")
 
+            my_N = nbeta
+            occ_list = occ_beta.copy()
+            my_v_r = vb_r.copy()
+            epsilon_beta[kid], Cbeta[kid] = scipy.sparse.linalg.eigsh(F_C, k=nbeta+1, which="SA")
+
+            # why do i need to orthonormalize my orbitals???
             Calpha[kid] = orthonormalize(Calpha[kid])
             Cbeta[kid] = orthonormalize(Cbeta[kid])
 
@@ -1214,17 +1175,17 @@ def uks(cell, basis,
             #epsilon_alpha, Calpha = np.linalg.eigh(fock_a)
             #epsilon_beta, Cbeta = np.linalg.eigh(fock_b)
 
-            # break spin symmetry?
-            if guess_mix is True and scf_iter == 0:
+            # break spin symmetry? # TODO this is broken, which probably indicates there is some other problem ...
+            #if guess_mix is True and scf_iter == 0:
 
-                c = np.cos(0.25 * np.pi)
-                s = np.sin(0.25 * np.pi)
+            #    c = np.cos(0.25 * np.pi)
+            #    s = np.sin(0.25 * np.pi)
 
-                tmp1 = c * Calpha[kid][:, nalpha-1] - s * Calpha[kid][:, nalpha]
-                tmp2 = s * Calpha[kid][:, nalpha-1] + c * Calpha[kid][:, nalpha]
+            #    tmp1 = c * Calpha[kid][:, nalpha-1] - s * Calpha[kid][:, nalpha]
+            #    tmp2 = s * Calpha[kid][:, nalpha-1] + c * Calpha[kid][:, nalpha]
 
-                Calpha[kid][:, nalpha-1] = tmp1
-                Calpha[kid][:, nalpha] = tmp2
+            #    Calpha[kid][:, nalpha-1] = tmp1
+            #    Calpha[kid][:, nalpha] = tmp2
 
             # update density
             my_rho_a, occ_alpha = get_density(basis, Calpha[kid], nalpha, kid)
@@ -1271,8 +1232,12 @@ def uks(cell, basis,
 
         else :
 
-            # we'll deal with hf exchange below
-            pass
+            # we'll deal with hf exchange matrices below ... here, just get the energy
+            xc_energy, exchange_matrix_alpha = get_exact_exchange_energy(basis, occ_alpha, nalpha, Calpha, exchange_matrix_alpha, False)
+            if nbeta > 0:
+                my_xc_energy, exchange_matrix_beta = get_exact_exchange_energy(basis, occ_beta, nbeta, Cbeta, exchange_matrix_beta, False)
+                xc_energy += my_xc_energy
+            xc_energy -= 0.5 * (nalpha + nbeta) * madelung
 
         # total energy
         new_total_energy = np.real(one_electron_energy) + np.real(coulomb_energy) + np.real(xc_energy) + enuc
@@ -1288,37 +1253,43 @@ def uks(cell, basis,
 
         print("    %5i %20.12lf %20.12lf %20.12lf %10.6lf" %  ( scf_iter, new_total_energy, energy_diff, conv, charge ) )
 
-        if xc != 'hf':
+        if conv < d_convergence and energy_diff < e_convergence :
+            break
 
-            if conv < d_convergence and energy_diff < e_convergence :
-                break
+        #inner_diis = lib.diis.DIIS()
+        #inner_diis.space = diis_dimension
 
-        else :
+        #if xc != 'hf':
 
-            if (conv < d_convergence and energy_diff < e_convergence and recompute_exchange) :
-                break
+        #    if conv < d_convergence and energy_diff < e_convergence :
+        #        break
 
-            elif (conv < d_convergence and energy_diff < e_convergence and not recompute_exchange or scf_iter == 0):
+        #else :
 
-                # update exchange matrix for next set of inner iterations
+        #    if (conv < d_convergence and energy_diff < e_convergence and recompute_exchange) :
+        #        break
 
-                # TODO: fix for general k
-                print('')
-                print('        ==> recomputing exchange matrix <==')
-                print('')
-                recompute_exchange = True
-                xc_energy, exchange_matrix_alpha = get_exact_exchange_energy(basis, occ_alpha, nalpha, Calpha, exchange_matrix_alpha, recompute_exchange)
-                if nbeta > 0:
-                    my_xc_energy, exchange_matrix_beta = get_exact_exchange_energy(basis, occ_beta, nbeta, Cbeta, exchange_matrix_beta, recompute_exchange)
-                    xc_energy += my_xc_energy
-                xc_energy -= 0.5 * (nalpha + nbeta) * madelung
+        #    elif (conv < d_convergence and energy_diff < e_convergence and not recompute_exchange or scf_iter == 0):
 
-                # reset diis ... not sure why this is necessary, but convergence is slow otherwise
-                inner_diis = lib.diis.DIIS()
-                inner_diis.space = diis_dimension
+        #        # update exchange matrix for next set of inner iterations
 
-            else :
-                recompute_exchange = False
+        #        # TODO: fix for general k
+        #        print('')
+        #        print('        ==> recomputing exchange matrix <==')
+        #        print('')
+        #        recompute_exchange = True
+        #        xc_energy, exchange_matrix_alpha = get_exact_exchange_energy(basis, occ_alpha, nalpha, Calpha, exchange_matrix_alpha, recompute_exchange)
+        #        if nbeta > 0:
+        #            my_xc_energy, exchange_matrix_beta = get_exact_exchange_energy(basis, occ_beta, nbeta, Cbeta, exchange_matrix_beta, recompute_exchange)
+        #            xc_energy += my_xc_energy
+        #        xc_energy -= 0.5 * (nalpha + nbeta) * madelung
+
+        #        # reset diis ... not sure why this is necessary, but convergence is slow otherwise
+        #        #inner_diis = lib.diis.DIIS()
+        #        #inner_diis.space = diis_dimension
+
+        #    else :
+        #        recompute_exchange = False
 
     if scf_iter == maxiter - 1:
         print('')

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -848,8 +848,8 @@ def uks(cell, basis,
 
     # nmo ... number of desired molecular orbitals ... must be at least ne
     # warning: ace has trouble for nmo > ne with eigsh, but lobpcg seems to work
-    nmo_alpha = nalpha + 1
-    nmo_beta = nbeta + 1
+    nmo_alpha = nalpha #+ 1
+    nmo_beta = nbeta #+ 1
     #if nbeta > nalpha:  
     #    nmo = nbeta
 

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -638,40 +638,6 @@ def get_one_electron_energy(basis, C, N, kid, v_ne = None, jellium = False):
 
     return one_electron_energy
 
-# TODO: don't store any npw x npw objects
-def get_coulomb_energy(basis, C, N, kid, v_coulomb):
-    """
-
-    get the coulomb contribution to the energy
-
-    :param basis: plane wave basis information
-    :param C: molecular orbital coefficients
-    :param N: the number of electrons
-    :param kid: index for a given k-point
-    :param v_coulomb: the coulomb potential
-
-    :return coulomb_energy: the coulomb contribution to the energy
-
-    """
-
-    # oei = 1/2 J
-    oei = np.zeros((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), dtype = 'complex128')
-    oei = get_matrix_elements(basis, kid, v_coulomb)
-
-    # only upper triangle of oei is populated ... symmetrize and rescale diagonal
-    oei = oei + oei.conj().T
-    
-    diag = np.diag(oei)
-    np.fill_diagonal(oei, 0.5 * diag)
-
-    tmporbs = np.zeros([basis.n_plane_waves_per_k[kid], N], dtype = 'complex128')
-    for pp in range(N):
-        tmporbs[:, pp] = C[:, pp]
-
-    coulomb_energy = 0.5 * np.einsum('pi,pq,qi->',tmporbs.conj(), oei, tmporbs) / len(basis.kpts)
-
-    return coulomb_energy
-
 def fock_on_orbitals(basis, kid, ne, nmo, occ, C, T, v_r, Vnl, xc):
     """
     evaluate action of fock matrix on orbitals and build ace operator
@@ -1289,11 +1255,11 @@ def uks(cell, basis,
                                                            v_ne = v_ne,
                                                            jellium = jellium)
 
-            # coulomb part of the energy: 1/2 J
-            coulomb_energy += get_coulomb_energy(basis, Calpha[kid], nalpha, kid, v_coulomb)
-
-            # coulomb part of the energy: 1/2 J
-            coulomb_energy += get_coulomb_energy(basis, Cbeta[kid], nbeta, kid, v_coulomb)
+        # coulomb part of the energy: 1/2 J
+        v_coulomb_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
+        v_coulomb_r.ravel()[basis.flat_idx] = v_coulomb
+        v_coulomb_r = np.fft.fftn(v_coulomb_r).real
+        coulomb_energy = 0.5 * ( basis.omega / ( basis.real_space_grid_dim[0] * basis.real_space_grid_dim[1] * basis.real_space_grid_dim[2] ) ) * np.sum((rho_alpha + rho_beta) * v_coulomb_r)
 
         # save old density
         rho_alpha_old = rho_alpha.copy()

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -429,20 +429,21 @@ def get_density(basis, C, Ne, Nmo, kid, occupation_numbers):
         phi = np.fft.fftn(phi) 
         phi_r.append(phi)
 
-        rho += np.absolute(phi)**2.0 / basis.omega * occupation_numbers[pp]**2
+        rho += np.absolute(phi)**2.0 / basis.omega * occupation_numbers[pp]
 
     return ( 1.0 / len(basis.kpts) ) * rho, phi_r
 
 # TODO: eliminate npw x npw storage
-def get_nonlocal_pp_energy(basis, C, N, kid):
+def get_nonlocal_pp_energy(basis, C, N, kid, occupation_numbers):
     """
 
     get nonlocal pseudopotential part of the energy
 
     :param basis: plane wave basis information
     :param C: molecular orbital coefficients
-    :param N: the number of electrons
+    :param N: the number of orbitals (formerly number of electrons, prior to smearing)
     :param kid: index for a given k-point
+    :param occupation_numbers: a list of occupation numbers (0, 1, or fermi-dirac for smearing)
 
     :return one_electron_energy: the nonlocal pseudopotential part of the energy
 
@@ -458,11 +459,12 @@ def get_nonlocal_pp_energy(basis, C, N, kid):
     diag = np.diag(oei)
     np.fill_diagonal(oei, 0.5 * diag)
 
-    tmporbs = np.zeros([basis.n_plane_waves_per_k[kid], N], dtype = 'complex128')
-    for pp in range(N):
-        tmporbs[:, pp] = C[:, pp]
+    #tmporbs = np.zeros([basis.n_plane_waves_per_k[kid], N], dtype = 'complex128')
+    #for pp in range(N):
+    #    tmporbs[:, pp] = C[:, pp] * np.sqrt(occupation_numbers[pp])
+    #nonlocal_pp_energy = np.einsum('pi,pq,qi->',tmporbs.conj(), oei, tmporbs) / len(basis.kpts)
 
-    nonlocal_pp_energy = np.einsum('pi,pq,qi->',tmporbs.conj(), oei, tmporbs) / len(basis.kpts)
+    nonlocal_pp_energy = np.einsum('pi,pq,qi->',C.conj(), oei, C * occupation_numbers) / len(basis.kpts)
 
     return nonlocal_pp_energy
 
@@ -690,8 +692,8 @@ def compute_local_potentials(rho_alpha, rho_beta, v_ne, basis, xc, libxc_x_funct
     v_coulomb = 4.0 * np.pi * rhog * basis.inv_g2
 
     # jellium ... but only true in the thermodynamic limit
-    if jellium:
-        v_coulomb *= 0.0
+    #if jellium:
+    #    v_coulomb *= 0.0
 
     # alpha- and beta-spin local potentials
     v_alpha = v_coulomb.copy()
@@ -718,6 +720,61 @@ def compute_local_potentials(rho_alpha, rho_beta, v_ne, basis, xc, libxc_x_funct
 
     return v_coulomb, v_alpha_r, v_beta_r
 
+def fermi_dirac(ne, eps, mu, kBT = None):
+    """
+    occupations from fermi–dirac distribution for given chemical potential
+
+    :param ne: number of electrons
+    :param eps: orbital energies
+    :param mu: chemical potential
+    :param kBT: boltzman factor times temperature
+
+    :return fermi-diract distribution
+    """
+    if kBT == None:
+        ret = np.zeros_like(eps).real
+        ret[:ne] = 1.0
+        return ret
+
+    x = (eps - mu) / kBT
+    return 1.0 / (np.exp(x) + 1.0)
+
+def find_chemical_potential(ne, eps, kBT = None, tol=1e-10, maxit = 200):
+    """
+    bisection search for chemical potential, mu, for fermi-dirac distribution:
+
+    sum_i f_i = ne
+
+    :param ne: number of electrons
+    :param eps: orbital energies
+    :param kBT: boltzman factor times temperature
+    :param tol: convergence threshold for bisection search
+    :param maxit: maximum number of iterations
+
+    """
+
+    if kBT == None:
+        return kBT
+
+    # bracket mu between min and max eigenvalue
+    mu_lo = np.min(eps) - 10.0 * kBT
+    mu_hi = np.max(eps) + 10.0 * kBT
+
+    # bisection search
+    for it in range(maxit):
+        mu_mid = 0.5 * (mu_lo + mu_hi)
+        n_mid = np.sum(fermi_dirac(ne, eps, mu_mid, kBT = kBT))
+        if n_mid > ne:
+            mu_hi = mu_mid
+        else:
+            mu_lo = mu_mid
+        if abs(mu_hi - mu_lo) < tol:
+            break
+    if it == maxit:
+        raise Exception('bisection search for the chemical potential failed.')
+
+    return mu_mid
+
 def uks(cell, basis, 
         xc = 'lda', 
         guess_mix = False, 
@@ -729,7 +786,8 @@ def uks(cell, basis,
         ace_exchange = True,
         jellium = False,
         jellium_ne = 2,
-        maxiter=500):
+        maxiter=500,
+        kBT=None):
 
     """
 
@@ -747,9 +805,10 @@ def uks(cell, basis,
     :return total energy
     :return Calpha: alpha MO coefficients
     :return Cbeta: beta MO coefficients
+    :return kBT: boltzman factor times temperature (for smearing)
 
     """
- 
+
     print('')
     print('    ************************************************')
     print('    *                                              *')
@@ -757,6 +816,12 @@ def uks(cell, basis,
     print('    *                                              *')
     print('    ************************************************')
     print('')
+
+    if len(basis.kpts) > 1 and kBT is not None:
+        raise Exception("smearing only works for the gamma point for now")
+
+    if len(basis.kpts) > 1 and xc == 'hf':
+        raise Exception("exact exchange only works for the gamma point for now")
 
     if xc != 'lda' and xc != 'pbe' and xc != 'hf' :
         raise Exception("uks only supports xc = 'lda' and 'hf' for now")
@@ -811,10 +876,21 @@ def uks(cell, basis,
     # diis 
     diis_start_cycle = damping_iterations
 
+    # nmo ... number of desired molecular orbitals ... must be at least ne
+    nmo_alpha = nalpha  #+ 1
+    nmo_beta = nbeta #+ 1
+    
+    # increase nmo if we're doing smearing
+    if kBT is not None:
+        nmo_alpha *= 2
+        nmo_beta *= 2
+
     print("")
     if jellium:
         rs = (3 * basis.omega / ( 4.0 * np.pi * (nalpha + nbeta)))**(1.0/3.0)
         print('    Wigner-Seitz radius (rs)                     %20.12f' % (rs))
+    if kBT is not None:
+        print('    kBT for smearing (eV)                        %20.12f' % (kBT * 27.21138602))
     print('    exchange functional:                         %20s' % ( functional_name_dict[xc][0] ) )
     print('    correlation functional:                      %20s' % ( functional_name_dict[xc][1] ) )
     print('    e_convergence:                               %20.2e' % ( e_convergence ) )
@@ -824,8 +900,10 @@ def uks(cell, basis,
     print('    no. basis functions (orbitals, gamma point): %20i' % ( basis.n_plane_waves_per_k[0] ) )
     print('    no. basis functions (density):               %20i' % ( len(basis.g) ) )
     print('    total_charge:                                %20i' % ( total_charge ) )
-    print('    no. alpha bands:                             %20i' % ( nalpha ) )
-    print('    no. beta bands:                              %20i' % ( nbeta ) )
+    print('    no. alpha occupied bands:                    %20i' % ( nalpha ) )
+    print('    no. beta occupied bands:                     %20i' % ( nbeta ) )
+    print('    no. total alpha bands:                       %20i' % ( nmo_alpha ) )
+    print('    no. total beta bands:                        %20i' % ( nmo_beta ) )
     print('    break spin symmetry:                         %20s' % ( "yes" if guess_mix is True else "no" ) )
     print('    damp density:                                %20s' % ( "yes" if damp_density is True else "no" ) )
     print('    no. damping iterations:                      %20i' % ( damping_iterations ) )
@@ -863,18 +941,17 @@ def uks(cell, basis,
     Ki_alpha = []
     Ki_beta = []
 
-    # nmo ... number of desired molecular orbitals ... must be at least ne
-    # warning: ace has trouble for nmo > ne with eigsh, but lobpcg seems to work
-    nmo_alpha = nalpha #+ 1
-    nmo_beta = nbeta #+ 1
-    #if nbeta > nalpha:  
-    #    nmo = nbeta
-
     # occupation numbers
     occ_num_alpha = np.ones(nmo_alpha, dtype=np.float64)
     occ_num_beta = np.ones(nmo_beta, dtype=np.float64)
     occ_num_alpha[nalpha:] = 0.0
     occ_num_beta[nbeta:] = 0.0
+
+    # kinetic energy
+    T = []
+    for kid in range ( len(basis.kpts) ):
+        kgtmp = basis.kpts[kid] + basis.g[basis.kg_to_g[kid, :basis.n_plane_waves_per_k[kid]]]
+        T.append(np.einsum('ij,ij->i', kgtmp, kgtmp) / 2.0)
 
     for kid in range ( len(basis.kpts) ):
 
@@ -888,7 +965,6 @@ def uks(cell, basis,
             Cbeta[kid][i, i] = 1.0
         Calpha[kid] = orthonormalize(Calpha[kid])
         Cbeta[kid] = orthonormalize(Cbeta[kid])
-        #Cbeta[kid] = Calpha[kid].copy()
 
         B_alpha_ace.append(np.zeros((nmo_alpha, nmo_alpha), dtype='complex128'))
         B_beta_ace.append(np.zeros((nmo_beta, nmo_beta), dtype='complex128'))
@@ -899,15 +975,19 @@ def uks(cell, basis,
         epsilon_alpha.append(np.zeros((nmo_alpha), dtype='complex128'))
         epsilon_beta.append(np.zeros((nmo_beta), dtype='complex128'))
 
+        # jellium orbital guess, plus some noise
+        if jellium:
+            eps_a, ca = np.linalg.eigh(np.diag(T[kid]))
+            epsilon_alpha[kid], Calpha[kid] = eps_a[:nmo_alpha], ca[:, :nmo_alpha]
+            Calpha[kid] += np.random.rand(basis.n_plane_waves_per_k[kid], nmo_alpha) * 1e-4
+            Calpha[kid] = orthonormalize(Calpha[kid])
+            Cbeta[kid] = Calpha[kid].copy()
+            #one_electron_energy = np.sum(np.einsum('pi,p->i', np.abs(Calpha[kid][:,:nalpha])**2, T[kid]))
+            #one_electron_energy += np.sum(np.einsum('pi,p->i', np.abs(Cbeta[kid][:,:nbeta])**2, T[kid]))
+
     # initialize phi_alpha and phi_beta arrays ... won't work for kpts > 0
     rho_alpha, phi_alpha = get_density(basis, Calpha[0], nalpha, nmo_alpha, kid, occ_num_alpha)
     rho_beta, phi_beta = get_density(basis, Cbeta[0], nbeta, nmo_beta, kid, occ_num_beta)
-
-    # kinetic energy
-    T = []
-    for kid in range ( len(basis.kpts) ):
-        kgtmp = basis.kpts[kid] + basis.g[basis.kg_to_g[kid, :basis.n_plane_waves_per_k[kid]]]
-        T.append(np.einsum('ij,ij->i', kgtmp, kgtmp) / 2.0)
 
     # jellium guess
     rho_alpha = nalpha / basis.omega * np.ones(basis.real_space_grid_dim, dtype = 'float64')
@@ -1027,27 +1107,48 @@ def uks(cell, basis,
             def lobpcg_beta(c):
                 return fock_on_orbitals_using_ace(basis, kid, nbeta, nmo_beta, phi_beta, c, T, v_beta_r, Vnl, xc, Ki_beta[kid], B_beta_ace[kid], ace_exchange, occ_num_beta)
 
+            Fa_C = LinearOperator((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), matvec=lobpcg_alpha, dtype='complex128')
+            Fb_C = LinearOperator((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), matvec=lobpcg_beta, dtype='complex128')
+
+            epsilon_alpha[kid], Calpha[kid] = scipy.sparse.linalg.lobpcg(Fa_C, Calpha[kid], largest=False, maxiter=200, tol=d_convergence*1e-1)
             if not jellium:
+                epsilon_beta[kid], Cbeta[kid] = scipy.sparse.linalg.lobpcg(Fb_C, Cbeta[kid], largest=False, maxiter=200, tol=d_convergence*1e-1)
+            else:
+                Cbeta[kid] = Calpha[kid].copy()
+                epsilon_beta[kid] = epsilon_alpha[kid].copy()
 
-                Fa_C = LinearOperator((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), matvec=lobpcg_alpha, dtype='complex128')
-                Fb_C = LinearOperator((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), matvec=lobpcg_beta, dtype='complex128')
+            # HF orbitals need to be shifted for smearing to work correctly
+            if xc == 'hf':
+                epsilon_alpha[kid] -= madelung * occ_num_alpha
+                epsilon_beta[kid] -= madelung * occ_num_beta
+                #epsilon_alpha[kid][:nalpha] -= madelung
+                #epsilon_beta[kid][:nbeta] -= madelung
+                #print(epsilon_alpha[kid])
+                #print(epsilon_beta[kid])
 
-                epsilon_alpha[kid], Calpha[kid] = scipy.sparse.linalg.lobpcg(Fa_C, Calpha[kid], largest=False, maxiter=200, tol=d_convergence*0.01)
-                epsilon_beta[kid], Cbeta[kid] = scipy.sparse.linalg.lobpcg(Fb_C, Cbeta[kid], largest=False, maxiter=200, tol=d_convergence*0.01)
+            #if not jellium:
 
-            else :
-                #epsilon_alpha[kid], Calpha[kid] = scipy.linalg.eigh(np.diag(T[kid]), eigvals=(0, nalpha))
-                #epsilon_beta[kid], Cbeta[kid] = scipy.linalg.eigh(fock_b[kid], eigvals=(0, nbeta))
+            #    Fa_C = LinearOperator((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), matvec=lobpcg_alpha, dtype='complex128')
+            #    Fb_C = LinearOperator((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), matvec=lobpcg_beta, dtype='complex128')
 
-                eps_a, ca = np.linalg.eigh(np.diag(T[kid]))
-                epsilon_alpha[kid], Calpha[kid] = eps_a[:nalpha], ca[:, :nalpha]
+            #    epsilon_alpha[kid], Calpha[kid] = scipy.sparse.linalg.lobpcg(Fa_C, Calpha[kid], largest=False, maxiter=200, tol=d_convergence*0.01)
+            #    epsilon_beta[kid], Cbeta[kid] = scipy.sparse.linalg.lobpcg(Fb_C, Cbeta[kid], largest=False, maxiter=200, tol=d_convergence*0.01)
 
-                #lowest_energy_T_index = np.argsort(T[kid])[:nalpha]
-                ##test = T[kid][lowest_energy_T_index]
-                #epsilon_alpha[kid] = T[kid][lowest_energy_T_index]
-                #Calpha[kid] = np.zeros((len(T[kid]), nalpha), dtype=np.complex128)
-                #for orb_idx, pw_idx in enumerate(lowest_energy_T_index):
-                #    Calpha[kid][pw_idx, orb_idx] = 1.
+            #else :
+
+            #    eps_a, ca = np.linalg.eigh(np.diag(T[kid]))
+            #    epsilon_alpha[kid], Calpha[kid] = eps_a[:nalpha], ca[:, :nalpha]
+
+            # update occupation numbers for smearing
+            mu_alpha = find_chemical_potential(nalpha, epsilon_alpha[kid], kBT = kBT)
+            mu_beta = find_chemical_potential(nbeta, epsilon_beta[kid], kBT = kBT)
+            #print('optimized mu (alpha)', mu_alpha)
+            #print('optimized mu (beta)', mu_beta)
+
+            occ_num_alpha = fermi_dirac(nalpha, epsilon_alpha[kid], mu_alpha, kBT = kBT)
+            occ_num_beta = fermi_dirac(nbeta, epsilon_beta[kid], mu_beta, kBT = kBT)
+            #print(occ_num_alpha)
+            #print(occ_num_beta)
 
             # break spin symmetry? # TODO this is broken, which probably indicates there is some other problem ...
             #if guess_mix is True and scf_iter == 0:
@@ -1076,13 +1177,13 @@ def uks(cell, basis,
             rho_beta += my_rho_beta.clip(min = 0)
 
             # kinetic energy part of the one-electron energy
-            one_electron_energy += np.sum(np.einsum('pi,p->i', np.abs(Calpha[kid][:,:nalpha])**2, T[kid]))
-            one_electron_energy += np.sum(np.einsum('pi,p->i', np.abs(Cbeta[kid][:,:nbeta])**2, T[kid]))
+            one_electron_energy += np.sum(np.einsum('pi,p->i', np.abs(Calpha[kid][:,:nmo_alpha])**2 * occ_num_alpha, T[kid]))
+            one_electron_energy += np.sum(np.einsum('pi,p->i', np.abs(Cbeta[kid][:,:nmo_beta])**2 * occ_num_beta, T[kid]))
 
             # nonlocal pseudopotential part of the energy
             if not jellium:
-                one_electron_energy += get_nonlocal_pp_energy(basis, Calpha[kid], nalpha, kid)
-                one_electron_energy += get_nonlocal_pp_energy(basis, Cbeta[kid], nbeta, kid)
+                one_electron_energy += get_nonlocal_pp_energy(basis, Calpha[kid], nmo_alpha, kid, occ_num_alpha)
+                one_electron_energy += get_nonlocal_pp_energy(basis, Cbeta[kid], nmo_beta, kid, occ_num_beta)
 
         # nuclear potential / local pseudopotential part of the one-electron energy
         if not jellium:
@@ -1108,9 +1209,9 @@ def uks(cell, basis,
         else :
 
             # exact exchange energy
-            xc_energy = get_exact_exchange_energy(basis, phi_alpha, nalpha, Calpha, occ_num_alpha)
+            xc_energy = get_exact_exchange_energy(basis, phi_alpha, nmo_alpha, Calpha, occ_num_alpha)
             if nbeta > 0:
-                my_xc_energy = get_exact_exchange_energy(basis, phi_beta, nbeta, Cbeta, occ_num_beta)
+                my_xc_energy = get_exact_exchange_energy(basis, phi_beta, nmo_beta, Cbeta, occ_num_beta)
                 xc_energy += my_xc_energy
 
             # jellium

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -539,7 +539,7 @@ def fock_on_orbitals(basis, kid, ne, nmo, phi_r, C, T, v_r, Vnl, xc, occupation_
 
     return F_c, Ki, exchange
 
-def fock_on_orbitals_using_ace(basis, kid, ne, nmo, phi_r, c, T, v_r, Vnl, xc, Ki, B_ace, ace_exchange, occupation_numbers):
+def fock_on_orbitals_using_ace(basis, kid, ne, nmo, phi_r, c, T, v_r, Vnl, xc, Ki, B_ace, ace_exchange, occupation_numbers, adiabatic_exchange_lambda):
     """
     apply fock operator to a set of orbitals using the ace operator
 
@@ -557,6 +557,7 @@ def fock_on_orbitals_using_ace(basis, kid, ne, nmo, phi_r, c, T, v_r, Vnl, xc, K
     :param B: ACE B matrix
     :param ace_exchange: do use the ace operator for exchange?
     :param occupation_numbers: a list of occupation numbers (0, 1, or fermi-dirac for smearing)
+    :param adiabatic_exchange_lambda: a scaling factor on the interval [0, 1] for ramping up exchange
 
     :return F @ c: action of fock operator on the orbitals in reciprococal space
     """
@@ -610,7 +611,7 @@ def fock_on_orbitals_using_ace(basis, kid, ne, nmo, phi_r, c, T, v_r, Vnl, xc, K
             # sum_i K | phi_i >  B_{ij} < phi_j | K | c >
             ace = Ki @ tmp 
 
-            F_c += ace
+            F_c += ace * adiabatic_exchange_lambda
  
         else :
 
@@ -619,7 +620,7 @@ def fock_on_orbitals_using_ace(basis, kid, ne, nmo, phi_r, c, T, v_r, Vnl, xc, K
             tmp = tmp.ravel()[basis.flat_idx] # reciprocal space, large flattened basis
             tmp = tmp[basis.kg_to_g[kid]] # reciprocal space, small flattened basis
             tmp = tmp.reshape(c.shape) # for lobpcg
-            F_c += tmp
+            F_c += tmp * adiabatic_exchange_lambda
 
     #print(np.linalg.norm(ace - tmp))
 
@@ -718,6 +719,10 @@ def compute_local_potentials(rho_alpha, rho_beta, v_ne, basis, xc, libxc_x_funct
     v_beta_r.ravel()[basis.flat_idx] = v_beta + v_ne
     v_beta_r = np.fft.fftn(v_beta_r).real
 
+    #if jellium:
+    #    v_alpha_r -= v_alpha_r.mean()
+    #    v_beta_r -= v_beta_r.mean()
+
     return v_coulomb, v_alpha_r, v_beta_r
 
 def fermi_dirac(ne, eps, mu, kBT = None):
@@ -775,19 +780,74 @@ def find_chemical_potential(ne, eps, kBT = None, tol=1e-10, maxit = 200):
 
     return mu_mid
 
+def kerker_preconditioning(rho_alpha, rho_beta, rho_alpha_old, rho_beta_old, basis, ne, q0 = None, alpha = 0.05):
+    """
+    kerker preconditioning
+    
+    :param rho_alpha: current alpha-spin density 
+    :param rho_beta: current beta-spin density
+    :param rho_alpha_old: previous alpha-spin density 
+    :param rho_beta_old: previous beta-spin density
+    :param basis: the plane-wave basis object
+    :param ne: number of electrons
+    :param q0: screening length. if None, chosen to be the Fermi wavevector for jellium
+    :param alpha: mixing parameter. default should be good for metallic systems
+    """
+
+    # 1. densities in reciprocal space
+    tmp = np.fft.ifftn(rho_alpha)
+    rho_alpha_G_new = tmp.ravel()[basis.flat_idx]
+
+    tmp = np.fft.ifftn(rho_alpha_old)
+    rho_alpha_G_old = tmp.ravel()[basis.flat_idx]
+
+    tmp = np.fft.ifftn(rho_beta)
+    rho_beta_G_new = tmp.ravel()[basis.flat_idx]
+
+    tmp = np.fft.ifftn(rho_beta_old)
+    rho_beta_G_old = tmp.ravel()[basis.flat_idx]
+
+    # 2. residual in reciprocal space
+    res_alpha_G = rho_alpha_G_new - rho_alpha_G_old
+    res_beta_G = rho_beta_G_new - rho_beta_G_old
+
+    # 3. preconditioner
+    if q0 is None:
+        q0 = np.sqrt(4.0/np.pi) * (3.0 * np.pi**2 * ne / basis.omega)**(1.0/6.0) # for jellium
+    P = basis.g2 / (basis.g2 + q0**2)
+    P[0] = 0.0
+
+    res_alpha_G_pre = res_alpha_G * P
+    res_beta_G_pre = res_beta_G * P
+
+    # 4. new density in reciprocal space
+    rho_alpha_G_new = rho_alpha_G_old + alpha * res_alpha_G_pre
+    rho_beta_G_new = rho_beta_G_old + alpha * res_beta_G_pre
+
+    # 5. new density in real space wtf
+    tmp.ravel()[basis.flat_idx] = rho_alpha_G_new
+    rho_alpha = np.fft.fftn(tmp).real
+    rho_alpha.clip(min = 0)
+
+    tmp.ravel()[basis.flat_idx] = rho_beta_G_new
+    rho_beta = np.fft.fftn(tmp).real
+    rho_beta.clip(min = 0)
+
+    return rho_alpha, rho_beta
+
 def uks(cell, basis, 
         xc = 'lda', 
         guess_mix = False, 
         e_convergence = 1e-8, 
         d_convergence = 1e-6, 
         diis_dimension = 8, 
-        damp_density = True, 
-        damping_iterations = 8,
         ace_exchange = True,
         jellium = False,
         jellium_ne = 2,
         maxiter=500,
-        kBT=None):
+        kBT=None,
+        kerker_q0=None,
+        kerker_alpha=0.05):
 
     """
 
@@ -799,13 +859,13 @@ def uks(cell, basis,
     :param guess_mix: do mix alpha homo and lumo to break spin symmetry?
     :param e_convergence: the convergence in the energy
     :param d_convergence: the convergence in the orbital gradient
-    :param damp_density: do dampen density?
-    :param damping_iterations: for how many iterations should we dampen the fock matrix
     :param maxiter: maximum number of scf iterations
     :return total energy
     :return Calpha: alpha MO coefficients
     :return Cbeta: beta MO coefficients
     :return kBT: boltzman factor times temperature (for smearing)
+    :param kerker_q0: screening length for kerker preconditioning. if None, chosen to be the Fermi wavevector for jellium
+    :param kerker_alpha: kerker mixing parameter. default should be good for metallic systems
 
     """
 
@@ -868,14 +928,6 @@ def uks(cell, basis,
         nbeta = jellium_ne // 2
         enuc = 0.0
 
-    # damp density (helps with convergence sometimes)
-    damping_factor = 1.0
-    if damp_density :
-        damping_factor = 0.8
-
-    # diis 
-    diis_start_cycle = damping_iterations
-
     # nmo ... number of desired molecular orbitals ... must be at least ne
     nmo_alpha = nalpha  #+ 1
     nmo_beta = nbeta #+ 1
@@ -905,10 +957,10 @@ def uks(cell, basis,
     print('    no. total alpha bands:                       %20i' % ( nmo_alpha ) )
     print('    no. total beta bands:                        %20i' % ( nmo_beta ) )
     print('    break spin symmetry:                         %20s' % ( "yes" if guess_mix is True else "no" ) )
-    print('    damp density:                                %20s' % ( "yes" if damp_density is True else "no" ) )
-    print('    no. damping iterations:                      %20i' % ( damping_iterations ) )
-    #print('    diis start iteration:                        %20i' % ( diis_start_cycle ) )
     print('    no. diis vectors:                            %20i' % ( diis_dimension ) )
+    if kerker_q0 is not None:
+        print('    kerker screening length                      %20.2f' % ( kerker_q0) )
+    print('    kerker mixing parameter                      %20.2f' % ( kerker_alpha) )
 
     if guess_mix :
         print("")
@@ -955,10 +1007,10 @@ def uks(cell, basis,
 
     for kid in range ( len(basis.kpts) ):
 
-        Calpha.append(np.random.rand(basis.n_plane_waves_per_k[kid], nmo_alpha) * 1e-8)
-        Cbeta.append(np.random.rand(basis.n_plane_waves_per_k[kid], nmo_beta) * 1e-8)
-        #Calpha.append(np.zeros((basis.n_plane_waves_per_k[kid], nmo_alpha), dtype='complex128'))
-        #Cbeta.append(np.zeros((basis.n_plane_waves_per_k[kid], nmo_beta), dtype='complex128'))
+        #Calpha.append(np.random.rand(basis.n_plane_waves_per_k[kid], nmo_alpha) * 1e-8)
+        #Cbeta.append(np.random.rand(basis.n_plane_waves_per_k[kid], nmo_beta) * 1e-8)
+        Calpha.append(np.zeros((basis.n_plane_waves_per_k[kid], nmo_alpha), dtype='complex128'))
+        Cbeta.append(np.zeros((basis.n_plane_waves_per_k[kid], nmo_beta), dtype='complex128'))
         for i in range (nmo_alpha):
             Calpha[kid][i, i] = 1.0
         for i in range (nmo_beta):
@@ -1009,6 +1061,7 @@ def uks(cell, basis,
     one_electron_energy = 0.0
     coulomb_energy = 0.0
 
+    adiabatic_exchange_lambda = 1.0
     for scf_iter in range(maxiter):
 
         one_electron_energy = 0.0
@@ -1016,11 +1069,6 @@ def uks(cell, basis,
 
         # compute local potentials
         v_coulomb, v_alpha_r, v_beta_r = compute_local_potentials(rho_alpha, rho_beta, v_ne, basis, xc, libxc_x_functional, libxc_c_functional, jellium)
-
-        # damping factor
-        damp = 1.0
-        if scf_iter < diis_start_cycle and damp_density : 
-            damp = damping_factor
 
         # evaluate the orbital gradient
         error_vector = np.zeros(0)
@@ -1044,8 +1092,8 @@ def uks(cell, basis,
                 B_alpha_ace[kid] = build_B_ace(nalpha, nmo_alpha, Calpha[kid], Ki_alpha[kid], exchange_alpha)
                 B_beta_ace[kid] = build_B_ace(nbeta, nmo_beta, Cbeta[kid], Ki_beta[kid], exchange_beta)
 
-                Fa_c += exchange_alpha
-                Fb_c += exchange_beta
+                Fa_c += exchange_alpha * adiabatic_exchange_lambda
+                Fb_c += exchange_beta * adiabatic_exchange_lambda
             
             Fa_c += Vnl @ Calpha[kid][:, :nmo_alpha]
             Fb_c += Vnl @ Cbeta[kid][:, :nmo_beta]
@@ -1063,12 +1111,8 @@ def uks(cell, basis,
         # norm of the orbital gradient for convergence check
         conv = np.linalg.norm(error_vector)
 
-        # damp or extrapolate density or potential
-        if scf_iter < diis_start_cycle:
-
-            # damping?
-            rho_alpha = (1.0-damp) * rho_alpha + damp * rho_alpha_old
-            rho_beta = (1.0-damp) * rho_beta + damp * rho_beta_old
+        # kerker preconditioning
+        rho_alpha, rho_beta = kerker_preconditioning(rho_alpha, rho_beta, rho_alpha_old, rho_beta_old, basis, nalpha + nbeta, q0 = kerker_q0, alpha = kerker_alpha)
 
         solution_vector = np.hstack( (rho_alpha.flatten(), rho_beta.flatten()) )
         new_solution_vector = diis.update(solution_vector, error_vector)
@@ -1079,7 +1123,7 @@ def uks(cell, basis,
         rho_alpha.clip(min = 0)
         rho_beta.clip(min = 0)
 
-        # recompute potentials after damping / diis extrapolation
+        # recompute potentials after kerker preconditioning and diis extrapolation
         v_coulomb, v_alpha_r, v_beta_r = compute_local_potentials(rho_alpha, rho_beta, v_ne, basis, xc, libxc_x_functional, libxc_c_functional, jellium)
 
         one_electron_energy = 0.0
@@ -1102,10 +1146,10 @@ def uks(cell, basis,
                 Vnl *= 0.0
 
             def lobpcg_alpha(c):
-                return fock_on_orbitals_using_ace(basis, kid, nalpha, nmo_alpha, phi_alpha, c, T, v_alpha_r, Vnl, xc, Ki_alpha[kid], B_alpha_ace[kid], ace_exchange, occ_num_alpha)
+                return fock_on_orbitals_using_ace(basis, kid, nalpha, nmo_alpha, phi_alpha, c, T, v_alpha_r, Vnl, xc, Ki_alpha[kid], B_alpha_ace[kid], ace_exchange, occ_num_alpha, adiabatic_exchange_lambda)
 
             def lobpcg_beta(c):
-                return fock_on_orbitals_using_ace(basis, kid, nbeta, nmo_beta, phi_beta, c, T, v_beta_r, Vnl, xc, Ki_beta[kid], B_beta_ace[kid], ace_exchange, occ_num_beta)
+                return fock_on_orbitals_using_ace(basis, kid, nbeta, nmo_beta, phi_beta, c, T, v_beta_r, Vnl, xc, Ki_beta[kid], B_beta_ace[kid], ace_exchange, occ_num_beta, adiabatic_exchange_lambda)
 
             Fa_C = LinearOperator((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), matvec=lobpcg_alpha, dtype='complex128')
             Fb_C = LinearOperator((basis.n_plane_waves_per_k[kid], basis.n_plane_waves_per_k[kid]), matvec=lobpcg_beta, dtype='complex128')
@@ -1139,6 +1183,11 @@ def uks(cell, basis,
             #    eps_a, ca = np.linalg.eigh(np.diag(T[kid]))
             #    epsilon_alpha[kid], Calpha[kid] = eps_a[:nalpha], ca[:, :nalpha]
 
+            #eps_a, ca = np.linalg.eigh(np.diag(T[kid]))
+            #epsilon_alpha[kid], Calpha[kid] = eps_a[:nmo_alpha], ca[:, :nmo_alpha]
+            #print(epsilon_alpha[kid])
+            #exit()
+
             # update occupation numbers for smearing
             mu_alpha = find_chemical_potential(nalpha, epsilon_alpha[kid], kBT = kBT)
             mu_beta = find_chemical_potential(nbeta, epsilon_beta[kid], kBT = kBT)
@@ -1147,6 +1196,7 @@ def uks(cell, basis,
 
             occ_num_alpha = fermi_dirac(nalpha, epsilon_alpha[kid], mu_alpha, kBT = kBT)
             occ_num_beta = fermi_dirac(nbeta, epsilon_beta[kid], mu_beta, kBT = kBT)
+            #print(occ_num_alpha)
             #print(occ_num_alpha)
             #print(occ_num_beta)
 
@@ -1237,7 +1287,10 @@ def uks(cell, basis,
         else :
             print("    %5i %20.12lf %20.12lf %20.12lf %10.6lf" %  ( scf_iter, new_total_energy, energy_diff, conv, charge))
 
-        if conv < d_convergence and energy_diff < e_convergence :
+        #if scf_iter < 1000:
+        #    adiabatic_exchange_lambda += 0.001
+
+        if conv < d_convergence and energy_diff < e_convergence: # and scf_iter >= 1000:
             break
 
     if scf_iter == maxiter - 1:

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -917,6 +917,8 @@ def uks(cell, basis,
 
     rho_alpha = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
     rho_beta = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
+    rho_alpha_old = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
+    rho_beta_old = np.zeros(basis.real_space_grid_dim, dtype = 'float64')
 
     for scf_iter in range(maxiter):
 
@@ -1116,22 +1118,51 @@ def uks(cell, basis,
         # norm of orbital gradient
         conv = np.linalg.norm(error_vector)
 
-        # damp or extrapolate potential
+        # damp or extrapolate density or potential
+        rho_alpha_old = rho_alpha.copy()
+        rho_beta_old = rho_beta.copy()
         if scf_iter < diis_start_cycle:
 
             # damping?
-            v_alpha = (1.0-damp) * v_alpha + damp * v_alpha_old
-            v_beta = (1.0-damp) * v_beta + damp * v_beta_old
+            #v_alpha = (1.0-damp) * v_alpha + damp * v_alpha_old
+            #v_beta = (1.0-damp) * v_beta + damp * v_beta_old
+            rho_alpha = (1.0-damp) * rho_alpha + damp * rho_alpha_old
+            rho_beta = (1.0-damp) * rho_beta + damp * rho_beta_old
 
         else :
 
             #v_coulomb = inner_diis.update(v_coulomb, error_vector)
 
-            solution_vector = np.hstack( (v_alpha, v_beta) )
+            solution_vector = np.hstack( (rho_alpha.flatten(), rho_beta.flatten()) )
+            #solution_vector = np.hstack( (v_alpha, v_beta) )
             new_solution_vector = inner_diis.update(solution_vector, error_vector)
-            v_alpha = new_solution_vector[:len(v_alpha)]
-            v_beta = new_solution_vector[len(v_alpha):]
+            #v_alpha = new_solution_vector[:len(v_alpha)]
+            #v_beta = new_solution_vector[len(v_alpha):]
+            rho_alpha = new_solution_vector[:len(solution_vector)//2].reshape(rho_alpha_old.shape)
+            rho_beta = new_solution_vector[len(solution_vector)//2:].reshape(rho_beta_old.shape)
 
+            rho_alpha.clip(min = 0)
+            rho_beta.clip(min = 0)
+
+        # rebuild potentials
+        rho = rho_alpha + rho_beta
+
+        # coulomb potential
+        tmp = np.fft.ifftn(rho)
+        for myg in range( len(basis.g) ):
+            inner_rhog[myg] = tmp[ get_miller_indices(myg, basis) ]
+
+        v_coulomb = 4.0 * np.pi * np.divide(inner_rhog, basis.g2, out = np.zeros_like(basis.g2), where = basis.g2 != 0.0)
+
+        # exchange-correlation potential
+        if xc != 'hf' :
+
+            v_xc_alpha, v_xc_beta = get_xc_potential(xc, basis, rho_alpha, rho_beta, libxc_x_functional, libxc_c_functional)
+            xc_energy = get_xc_energy(xc, basis, rho_alpha, rho_beta, libxc_x_functional, libxc_c_functional)
+
+        v_alpha = v_coulomb + v_xc_alpha
+        v_beta = v_coulomb + v_xc_beta
+    
         # potential in real space
         v_alpha_r = np.zeros(basis.real_space_grid_dim, dtype = 'complex128')
         v_alpha_r.ravel()[flat_idx] = v_alpha + v_ne

--- a/qcpanop/pw_pbc/scf.py
+++ b/qcpanop/pw_pbc/scf.py
@@ -709,7 +709,7 @@ def uks(cell, basis,
         e_convergence = 1e-8, 
         d_convergence = 1e-6, 
         diis_dimension = 8, 
-        damp_fock = True, 
+        damp_density = True, 
         damping_iterations = 8,
         ace_exchange = True,
         jellium = False,
@@ -726,7 +726,7 @@ def uks(cell, basis,
     :param guess_mix: do mix alpha homo and lumo to break spin symmetry?
     :param e_convergence: the convergence in the energy
     :param d_convergence: the convergence in the orbital gradient
-    :param damp_fock: do dampen fock matrix?
+    :param damp_density: do dampen density?
     :param damping_iterations: for how many iterations should we dampen the fock matrix
     :param maxiter: maximum number of scf iterations
     :return total energy
@@ -796,7 +796,7 @@ def uks(cell, basis,
 
     # damp fock matrix (helps with convergence sometimes)
     damping_factor = 1.0
-    if damp_fock :
+    if damp_density :
         damping_factor = 0.8
 
     # diis 
@@ -817,7 +817,7 @@ def uks(cell, basis,
     print('    no. alpha bands:                             %20i' % ( nalpha ) )
     print('    no. beta bands:                              %20i' % ( nbeta ) )
     print('    break spin symmetry:                         %20s' % ( "yes" if guess_mix is True else "no" ) )
-    print('    damp fock matrix:                            %20s' % ( "yes" if damp_fock is True else "no" ) )
+    print('    damp density:                                %20s' % ( "yes" if damp_density is True else "no" ) )
     print('    no. damping iterations:                      %20i' % ( damping_iterations ) )
     #print('    diis start iteration:                        %20i' % ( diis_start_cycle ) )
     print('    no. diis vectors:                            %20i' % ( diis_dimension ) )
@@ -998,7 +998,7 @@ def uks(cell, basis,
 
         # damping factor
         damp = 1.0
-        if scf_iter < diis_start_cycle and damp_fock : 
+        if scf_iter < diis_start_cycle and damp_density : 
             damp = damping_factor
 
         # orbital gradient


### PR DESCRIPTION
faster exact exchange in PW-SCF. major changes:

- implements ace
- eliminates storage of fock matrix (except for non-local part of the pseudopotential)
- without storing fock matrix, diagonalization is done using davidson and function to evaluate action of F on an orbital
- changes how DIIS works. currently extrapolates the potential with orbital-based gradient instead of [D, F]

problems:

- breaking spin symmetry no longer works